### PR TITLE
Fix Ubuntu package for GMP mentioned in install

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -45,19 +45,19 @@ Linux Ubuntu
 
 For Python 2.x::
 
-        $ sudo apt-get install build-essential libgmp3c2 python-dev
+        $ sudo apt-get install build-essential libgmp3-dev python-dev
         $ pip install pycryptodomex
         $ python -m Cryptodome.SelfTest
 
 For Python 3.x::
 
-        $ sudo apt-get install build-essential libgmp3c2 python3-dev
+        $ sudo apt-get install build-essential libgmp3-dev python3-dev
         $ pip install pycryptodomex
         $ python3 -m Cryptodome.SelfTest
 
 For PyPy::
 
-        $ sudo apt-get install build-essential libgmp3c2 pypy-dev
+        $ sudo apt-get install build-essential libgmp3-dev pypy-dev
         $ pip install pycryptodomex
         $ pypy -m Cryptodome.SelfTest
 


### PR DESCRIPTION
The correct package looks to be `libgmp3-dev`, not `libgmp3c2`, see: http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libgmp3&searchon=names

The latter is only available on `precise`, the former is available on all modern Ubuntu versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/legrandin/pycryptodome/19)
<!-- Reviewable:end -->
