### PR TITLE
Comment out deprecated Warning call

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -49,8 +49,8 @@ except ImportError:
     _fastmath = None
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
-# if _fastmath is not None and not (hasattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC") and _fastmath.HAVE_DECL_MPZ_POWM_SEC):
-#    _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
+if _fastmath is not None and not (hasattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC") and _fastmath.HAVE_DECL_MPZ_POWM_SEC):
+    _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", UserWarning)
 
 # New functions
 from _number_new import *

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -49,8 +49,8 @@ except ImportError:
     _fastmath = None
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
-if _fastmath is not None and not (hasattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC") and _fastmath.HAVE_DECL_MPZ_POWM_SEC):
-    _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
+# if _fastmath is not None and not (hasattr(_fastmath, "HAVE_DECL_MPZ_POWM_SEC") and _fastmath.HAVE_DECL_MPZ_POWM_SEC):
+#    _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
 
 # New functions
 from _number_new import *


### PR DESCRIPTION
Commented out a superfluous if statement containing a reference to the PowmInsecureWarning that was previously removed.

Addresses issue #20 