### PR TITLE
Remove implementation of deprecated PGP "quick check"

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,3 +1,4 @@
+Simon Arneaud
 Nevins Bartolomeo
 Thorsten E. Behrens
 Tim Berners-Lee

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -9,6 +9,7 @@ Resolved issues
 
 * Undefined warning was raised with libgmp version < 5
 * Forgot inclusion of ``alloca.h``
+* Removed implementation of deprecated "quick check" feature of PGP block cipher mode.
 
 3.4.2 (8 March 2016)
 +++++++++++++++++++

--- a/lib/Crypto/Cipher/_mode_openpgp.py
+++ b/lib/Crypto/Cipher/_mode_openpgp.py
@@ -41,16 +41,17 @@ class OpenPgpMode(object):
     """OpenPGP mode.
 
     This mode is a variant of CFB, and it is only used in PGP and
-    OpenPGP_ applications.
+    OpenPGP_ applications. If in doubt, use another mode.
 
     An Initialization Vector (*IV*) is required.
 
     Unlike CFB, the *encrypted* IV (not the IV itself) is
     transmitted to the receiver.
 
-    The IV is a random data block. Two of its bytes are duplicated to act
-    as a checksum for the correctness of the key. The encrypted IV is
-    therefore 2 bytes longer than the clean IV.
+    The IV is a random data block. For legacy reasons, two of its bytes are
+    duplicated to act as a checksum for the correctness of the key, which is now
+    known to be insecure and is ignored. The encrypted IV is therefore 2 bytes
+    longer than the clean IV.
 
     .. _OpenPGP: http://tools.ietf.org/html/rfc4880
 
@@ -80,8 +81,8 @@ class OpenPgpMode(object):
             # ... decryption
             self._encrypted_IV = iv
             iv = IV_cipher.decrypt(iv)
-            if iv[-2:] != iv[-4:-2]:
-                raise ValueError("Failed integrity check for OPENPGP IV")
+            # First two bytes are for a deprecated "quick check" feature that
+            # should not be used. (https://eprint.iacr.org/2005/033)
             iv = iv[:-2]
         else:
             raise ValueError("Length of IV must be %d or %d bytes"


### PR DESCRIPTION
PGP's block cipher mode makes the first two bytes of the second block a duplicate of two bytes from the IV.  This redundancy was included in PGP as a quick way to check the right decryption key is being used, but was later discovered to not be cryptographically secure -- in some cases it can be exploited to partially decrypt messages (https://eprint.iacr.org/2005/033).  Modern, secure implementations don't use the check, so the two bytes are only there for backwards compatibility.

The OpenPGP standard now includes encryption with cryptographic hashes for integrity protection.