### PR TITLE
Fix AES.CCM example and clarify default nonce handling

### DIFF
--- a/lib/Crypto/Cipher/AES.py
+++ b/lib/Crypto/Cipher/AES.py
@@ -43,18 +43,18 @@ The CCM mode optionally allows the header of the message to remain in the clear,
 whilst still being authenticated. The encryption is done as follows:
 
     >>> from Crypto.Cipher import AES
-    >>> from Crypto.Random import get_random_bytes
-    >>>
     >>>
     >>> hdr = b'To your eyes only'
     >>> plaintext = b'Attack at dawn'
     >>> key = b'Sixteen byte key'
-    >>> cipher = AES.new(key, AES.MODE_CCM, nonce)
+    >>> cipher = AES.new(key, AES.MODE_CCM)
     >>> cipher.update(hdr)
     >>> msg = cipher.nonce, hdr, cipher.encrypt(plaintext), cipher.digest()
 
 We assume that the tuple ``msg`` is transmitted to the receiver:
 
+    >>> from Crypto.Cipher import AES
+    >>>
     >>> nonce, hdr, ciphertext, mac = msg
     >>> key = b'Sixteen byte key'
     >>> cipher = AES.new(key, AES.MODE_CCM, nonce)

--- a/lib/Crypto/Cipher/AES.py
+++ b/lib/Crypto/Cipher/AES.py
@@ -66,9 +66,13 @@ We assume that the tuple ``msg`` is transmitted to the receiver:
     >>> except ValueError:
     >>>     print "Key incorrect or message corrupted"
 
+If no ``nonce`` is supplied initially, a 11 bytes random ``nonce`` is generated,
+which is good for a maximum message size of 4G. See CCM_.
+
 .. __: http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
 .. _NIST: http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf
 .. _AEAD: http://blog.cryptographyengineering.com/2012/05/how-to-choose-authenticated-encryption.html
+.. _CCM: Crypto.Cipher._mode_ccm.CcmMode-class.html
 
 :undocumented: __package__
 """


### PR DESCRIPTION
Hi, first of all, thanks for continuing this project. As matters stand, you're filling a *huge* gap, that was created by the PyCrypto development stall, while powerful and sustainable cryptography gets increasingly more important for our times. Much appreciated.

While taking the first steps in this project, I noticed a documentation glitch, that is fixed with the supplied PR. I would love to see this merged.

BTW, I started to build this package on openSUSE build service:
https://build.opensuse.org/package/show/home:frispete:python/python-pycryptodome
https://build.opensuse.org/package/show/home:frispete:python3/python3-pycryptodome
which is the first step for getting it into future distributions.

Cheers,
Pete 