### PR TITLE
Fix PEM marker for PKCS#1

### DIFF
--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -365,7 +365,7 @@ class RsaKey(object):
                                             passphrase, protection)
                     passphrase = None
         else:
-            key_type = "RSA PUBLIC KEY"
+            key_type = "PUBLIC KEY"
             binary_key = _create_subject_public_key_info(oid,
                                                          DerSequence([self.n,
                                                                       self.e])


### PR DESCRIPTION
Fix PEM marker back to PKCS#1. The never-released PyCrypto 2.7 implemented PKCS#8 serialization for private RSA key, but didn't implement it correctly for public key, which uses SubjectPublicKeyInfo. Pycryptodome was obviously forked from master, which included incorrect marker.

See https://github.com/dlitz/pycrypto/blame/2.6.x/lib/Crypto/PublicKey/RSA.py#L369 and https://github.com/dlitz/pycrypto/blame/master/lib/Crypto/PublicKey/RSA.py#L429