### PR TITLE
Assume PBKDF2's salt parameter is a string

### DIFF
--- a/lib/Crypto/Protocol/KDF.py
+++ b/lib/Crypto/Protocol/KDF.py
@@ -124,6 +124,7 @@ def PBKDF2(password, salt, dkLen=16, count=1000, prf=None):
         If you wanted multiple keys, just break up this string into segments of the desired length.
 """
     password = tobytes(password)
+    salt = tobytes(salt)
     if prf is None:
         prf = lambda p,s: HMAC.new(p,s,SHA1).digest()
 

--- a/lib/Crypto/SelfTest/Protocol/test_KDF.py
+++ b/lib/Crypto/SelfTest/Protocol/test_KDF.py
@@ -91,8 +91,8 @@ class PBKDF2_Tests(unittest.TestCase):
 
         for i in xrange(len(self._testData)):
             v = self._testData[i]
-            res  = PBKDF2(v[0], t2b(v[1]), v[2], v[3])
-            res2 = PBKDF2(v[0], t2b(v[1]), v[2], v[3], prf)
+            res  = PBKDF2(v[0], v[1], v[2], v[3])
+            res2 = PBKDF2(v[0], v[1], v[2], v[3], prf)
             self.assertEqual(res, t2b(v[4]))
             self.assertEqual(res, res2)
 


### PR DESCRIPTION
This PR fixes #66 

It changes the assumption that PBKDF2's salt parameter should be a byte array and brings it inline with the documentation.

It is important to note that PBKDF1 explicitly expects a byte array, but I propose we keep this conversation elsewhere. This is a symptom of a bigger python 2 -> 3 issue with strings/bytes.