### PR TITLE
add DSA size functions

### DIFF
--- a/lib/Crypto/PublicKey/DSA.py
+++ b/lib/Crypto/PublicKey/DSA.py
@@ -352,6 +352,14 @@ class DsaKey(object):
     def size(self):
         raise NotImplementedError
 
+    def size_in_bits(self):
+        """Size of the DSA modulus in bits"""
+        return len(bin(self.p)) - 2
+
+    def size_in_bytes(self):
+        """The minimal amount of bytes that can hold the DSA modulus"""
+        return (self.size_in_bits() - 1) // 8 + 1
+
 
 def _generate_domain(L, randfunc):
     """Generate a new set of DSA domain parameters"""

--- a/lib/Crypto/SelfTest/PublicKey/test_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_DSA.py
@@ -173,6 +173,11 @@ class DSATest(unittest.TestCase):
         self.failUnless(dsaObj._verify(m_hash, (r, s)))
         self.failIf(dsaObj._verify(m_hash + 1, (r, s)))
 
+    def test_size(self):
+        dsaObj = self.dsa.generate(1024)
+        self.assertEquals(dsaObj.size_in_bits(), 1024)
+        self.assertEquals(dsaObj.size_in_bytes(), 128)
+
 
 class DSADomainTest(unittest.TestCase):
 


### PR DESCRIPTION
These functions (already defined for RSA keys) calculate the length of a
DSA key. Unlike RSA keys, the DSA modulus is stored as a long, so the
size must be computed separately. The use of `bit_length` was avoided
for < python2.7 compatibility.