### PR TITLE
Update the claim of ElGamal

### DIFF
--- a/Doc/src/public_key/elgamal.rst
+++ b/Doc/src/public_key/elgamal.rst
@@ -2,9 +2,7 @@ El Gamal
 ========
 
 .. warning::
-    Even though ElGamal algorithms are in theory reasonably secure,
-    in practice there are no real good reasons to prefer them to :doc:`rsa`
-    instead.
+    This implementation of ElGamal is only secure if used for hybrid encryption.
 
 Signature algorithm
 -------------------


### PR DESCRIPTION
The ElGamal implementation can be used for hybrid encryption (where it is used to encrypt a key).

But still cannot be secure to directly encrypt messages (like my passwords).

I would suggest changing the claim in the documentation, to avoid new developers use this algorithm for purposes beyond hybrid encryption. 