### PR TITLE
Fix CTR block size error message

### DIFF
--- a/lib/Crypto/Cipher/_mode_ctr.py
+++ b/lib/Crypto/Cipher/_mode_ctr.py
@@ -345,7 +345,7 @@ def _create_ctr_cipher(factory, **kwargs):
     initial_counter_block = prefix + b("").join(words) + suffix
 
     if len(initial_counter_block) != factory.block_size:
-        raise ValueError("Size of the counter block (% bytes) must match"
+        raise ValueError("Size of the counter block (%d bytes) must match"
                          " block size (%d)" % (len(initial_counter_block),
                                                factory.block_size))
 


### PR DESCRIPTION
The format string is interpreting `% bytes` as `%b` instead of the proper `%d`, resulting in an ugly error message:

```
ValueError: unsupported format character 'b' (0x62) at index 29
```