### PR TITLE
Allow bytearrays in byte_string

### DIFF
--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -105,7 +105,7 @@ else:
     def tostr(bs):
         return bs.decode("latin-1")
     def byte_string(s):
-        return isinstance(s, bytes)
+        return isinstance(s, (bytes, bytearray))
 
     # With Python 3.[0-2], unhexlify only accepts bytes.
     # Starting from Python 3.3, strings can be passed too.


### PR DESCRIPTION
The PR ethereum/eth-hash#5 failed because pycryptome doesn't allow `bytearrays` for hashing. This PR fixes that by allowing `bytearray` in the `byte_string` function.