### PR TITLE
change addmul128 return type to size_t

### DIFF
--- a/src/multiply_64.c
+++ b/src/multiply_64.c
@@ -54,7 +54,7 @@ DAMAGE.
 
 #endif
 
-uint64_t addmul128(uint64_t * RESTRICT t, const uint64_t * RESTRICT a, uint64_t b0, uint64_t b1, size_t words)
+size_t addmul128(uint64_t * RESTRICT t, const uint64_t * RESTRICT a, uint64_t b0, uint64_t b1, size_t words)
 {
     uint64_t sum_low, sum_mid, sum_hi;
     uint64_t pr_low, pr_high, aim1;


### PR DESCRIPTION
As of the v3.5.0 release, I've been unable to uninstall pycryptodome on my macOS Sierra machine running Python 3.6. A coworker experienced the same issue using Anaconda Python 3.6 on High Sierra. The backtrace is super long, but this looks like the relevant part:

```
    src/montgomery.c:144:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i=0; i<b_words; i++) {
                  ~^~~~~~~~
    src/montgomery.c:154:26: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (; borrow2>0 && i<a_words; i++) {
                            ~^~~~~~~~
    src/montgomery.c:181:16: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i=0; i<elle*2; i++) {
                  ~^~~~~~~
    src/montgomery.c:224:16: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i=0; i<(abn_words & ~1); i+=2) {
                  ~^ ~~~~~~~~~~~~~~
    src/montgomery.c:489:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i=0; i<len && *exp==0; i++) {
                  ~^~~~
    5 warnings generated.
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DHAVE_X86INTRIN_H -DPY_LITTLE_ENDIAN -DLTC_NO_ASM -DHAVE_UINT128 -DHAVE_CPUID_H -Isrc/ -I/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framewo
rk/Versions/3.6/include/python3.6m -c src/siphash.c -o build/temp.macosx-10.12-x86_64-3.6/src/siphash.o -msse2
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DHAVE_X86INTRIN_H -DPY_LITTLE_ENDIAN -DLTC_NO_ASM -DHAVE_UINT128 -DHAVE_CPUID_H -Isrc/ -I/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framewo
rk/Versions/3.6/include/python3.6m -c src/montgomery_utils.c -o build/temp.macosx-10.12-x86_64-3.6/src/montgomery_utils.o -msse2
    src/montgomery_utils.c:35:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (j=0; j<partial; j++) {
                  ~^~~~~~~~
    1 warning generated.
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -DHAVE_X86INTRIN_H -DPY_LITTLE_ENDIAN -DLTC_NO_ASM -DHAVE_UINT128 -DHAVE_CPUID_H -Isrc/ -I/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framewo
rk/Versions/3.6/include/python3.6m -c src/multiply_64.c -o build/temp.macosx-10.12-x86_64-3.6/src/multiply_64.o -msse2
    src/multiply_64.c:57:10: error: conflicting types for 'addmul128'
    uint64_t addmul128(uint64_t * RESTRICT t, const uint64_t * RESTRICT a, uint64_t b0, uint64_t b1, size_t words)
             ^
    src/multiply.h:62:8: note: previous declaration is here
    size_t addmul128(uint64_t * RESTRICT t, const uint64_t * RESTRICT a, uint64_t b0, uint64_t b1, size_t words)
           ^
    1 error generated.
    error: command 'clang' failed with exit status 1

    ----------------------------------------
```

I think the problem is that `addmul128` is declared to return a `size_t` in the [header file](https://github.com/Legrandin/pycryptodome/blob/v3.5.0/src/multiply.h#L62), but it's implementation returns a `uint64_t` [here](https://github.com/Legrandin/pycryptodome/blob/v3.5.0/src/multiply_64.c#L57).

I don't know nearly enough about the `pycryptodome` package to know if this change is correct or sensible -- it could be that this method should indeed be returning a `unit64_t` and it's the header that's incorrect. Or, it might be something else entirely. Making this change allowed me to install from source though :)

Happy to help however I can! Thanks