### PR TITLE
Build wheels on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ matrix:
    env: CFFI=no OLDPY=python3.2
  - python: 3.4
    env: CFFI=yes OLDPY=python3.2
+ - os: osx
+   language: generic
+   install: pip2 install cibuildwheel==0.7.0
+   after_success: 
+   -  cibuildwheel --output-dir wheelhouse;
+      touch .separate_namespace;
+      cibuildwheel --output-dir wheelhouse;
+      ls wheelhouse;
 services:
  - docker
 branches:


### PR DESCRIPTION
This makes Travis build binary wheels on macOS too.

The changes in this PR are not too spectacular, most of the work is done by [🎡cibuildwheel](https://github.com/joerick/cibuildwheel) - actually this was really simple. Please let me know if I forgot something.

I tested a wheel on my MacBook and it appears to be working fine.

Closes: #147 