### PR TITLE
Add mingw(32/64) compatibility

### DIFF
--- a/src/montgomery.c
+++ b/src/montgomery.c
@@ -372,7 +372,7 @@ int allocate_montgomery(struct Montgomery *m, size_t words)
     }
     allocate(m->power_idx, words);
     
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     m->prot = _aligned_malloc((1<<WINDOW_SIZE)*words*8, CACHE_LINE_SIZE);
 #else
     result = posix_memalign((void**)&m->prot, CACHE_LINE_SIZE, (1<<WINDOW_SIZE)*words*8);


### PR DESCRIPTION
The function posix_memalign is missing on the mingw platform (as well). This patch adds compatibility to the mingw32 and mingw64 platform. See https://www.gnu.org/software/gnulib/manual/html_node/posix_005fmemalign.html