### PR TITLE
Update rsa.rst

### DIFF
--- a/Doc/src/public_key/rsa.rst
+++ b/Doc/src/public_key/rsa.rst
@@ -27,7 +27,7 @@ called ``mykey.pem``, and then read it back::
     >>>
     >>> key = RSA.generate(2048)
     >>> f = open('mykey.pem','w')
-    >>> f.write(key.export_key('PEM'))
+    >>> f.write( key.export_key('PEM').decode("utf-8") )
     >>> f.close()
     ...
     >>> f = open('mykey.pem','r')


### PR DESCRIPTION
write() argument must be str, not bytes. Line 30 fails, however can be fixed using decode() method.