### PR TITLE
Docs: Call `verify` on the verifier object, not the hash

### DIFF
--- a/Doc/src/signature/signature.rst
+++ b/Doc/src/signature/signature.rst
@@ -33,7 +33,7 @@ Verifying a signature
 2. You instatiate a cryptographic hash (see :mod:`Crypto.Hash`) and digest
    the message with it.
 
-3. You call :func:`verify` on the hash object and the incoming signature.
+3. You call :func:`verify` on the verifier object, passing in the hash and incoming signature.
    If the message is not authentic, an :py:exc:`ValueError` is raised.
 
 Available mechanisms


### PR DESCRIPTION
I think the example code should look like this:
```
key = ECC.import_key(...)
verifier = DSS.new(key, 'fips-186-3')
hash_object = SHA256.new(data=...)
signature = <the sha256>
verifier.verify(hash_object, signature)
```
Reference: https://www.pycryptodome.org/en/latest/src/signature/dsa.html?highlight=dss#Crypto.Signature.DSS.DssSigScheme.verify