### PR TITLE
Fix use of the deprecated imp module in Python 3

### DIFF
--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -35,7 +35,7 @@ from Crypto.Util._file_system import pycryptodome_filename
 #
 # List of file suffixes for Python extensions
 #
-if sys.version_info[0] <= 3 or \
+if sys.version_info[0] < 3 or \
    (sys.version_info[0] == 3 and sys.version_info[1] <= 3):
 
     import imp


### PR DESCRIPTION

    Util/_raw_api.py:41: DeprecationWarning: the imp module is deprecated in favour of importlib

In fact, the condition was always true whatever the Python version.