### PR TITLE
Increase accuracy of the Lucas primality test

### DIFF
--- a/lib/Crypto/Math/Primality.py
+++ b/lib/Crypto/Math/Primality.py
@@ -136,7 +136,7 @@ def lucas_test(candidate):
     def alternate():
         sgn = 1
         value = 5
-        for x in xrange(10):
+        for x in xrange(20):
             yield sgn * value
             sgn, value = -sgn, value + 2
 


### PR DESCRIPTION
The lucas test implementation is uses at most 10 elements from the sequence  {5, –7, 9, –11, 13, –15, 17, … }. For very little performance penalty this could be increased to improve the false-positive rate of the algorithm. Here I have increased the sequence size to 20.

The algorithm as specified in para C 3.3 from nist.fips.186 assumes no limit to the length of this sequence, but practically there should be a limit. I think increasing the sequence size is good enough, but there may be a better way. 