### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -331,7 +331,7 @@ def getStrongPrime(N, e=0, false_positive_prob=1e-6, randfunc=None):
     return X
 
 def isPrime(N, false_positive_prob=1e-6, randfunc=None):
-    """Test if a number *N* is a prime.
+    r"""Test if a number *N* is a prime.
 
     Args:
         false_positive_prob (float):


### PR DESCRIPTION
Fixes the Python 3 warning:
```python
/Util/number.py:227: DeprecationWarning: invalid escape sequence \ 
  """
/Util/number.py:349: DeprecationWarning: invalid escape sequence \ 
  """
```
I used the same fix as it was done in [requests](https://github.com/requests/requests/pull/3956/files).