### PR TITLE
Drop support for Python < 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ PyCryptodome
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
 
-It supports Python 2.4 or newer, all Python 3 versions and PyPy.
+It supports Python 2.6 or newer, all Python 3 versions and PyPy.
 
 You can install it with::
 


### PR DESCRIPTION
This was missed in https://github.com/Legrandin/pycryptodome/commit/2d2f8bf85a7d09fdc6eeef5ff8e451d689f4e5e9.