### PR TITLE
Drop support for EOL Python 2.4

### DIFF
--- a/Doc/src/contribute_support.rst
+++ b/Doc/src/contribute_support.rst
@@ -17,11 +17,11 @@ Contribute and support
 
 - Provide tests (in ``Crypto.SelfTest``) along with code. If you fix a bug
   add a test that fails in the current version and passes with your change.
-- If your change breaks backward compatibility, hightlight it and include
+- If your change breaks backward compatibility, highlight it and include
   a justification.
 - Ensure that your code complies to `PEP8`_ and `PEP257`_.
 - Ensure that your code does not use constructs or includes modules not
-  present in `Python 2.4`_.
+  present in `Python 2.6`_.
 - Add a short summary of the change to the file ``Changelog.rst``.
 - Add your name to the list of contributors in the file ``AUTHORS.rst``.
 
@@ -30,10 +30,10 @@ You can mail any comment or question to *pycryptodome@googlegroups.com*.
 
 Bug reports can be filed on the `GitHub tracker <https://github.com/Legrandin/pycryptodome/issues>`_.
 
-.. _BSD 2-clause license: http://opensource.org/licenses/BSD-2-Clause
+.. _BSD 2-clause license: https://opensource.org/licenses/BSD-2-Clause
 .. _GitHub: https://github.com/Legrandin/pycryptodome
-.. _pull request: https://help.github.com/articles/using-pull-requests
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
-.. _MIT license: http://opensource.org/licenses/MIT
-.. _PEP257: http://legacy.python.org/dev/peps/pep-0257/
-.. _Python 2.4: http://rgruet.free.fr/PQR24/PQR2.4.html
+.. _pull request: https://help.github.com/articles/about-pull-requests/
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _MIT license: https://opensource.org/licenses/MIT
+.. _PEP257: https://legacy.python.org/dev/peps/pep-0257/
+.. _Python 2.6: https://rgruet.free.fr/PQR26/PQR2.6.html

--- a/pct-speedtest.py
+++ b/pct-speedtest.py
@@ -59,12 +59,6 @@ try:
 except ImportError: # Some builds/versions of Python don't have a hashlib module
     hashlib = hmac = None
 
-# os.urandom() is less noisy when profiling, but it doesn't exist in Python < 2.4
-try:
-    urandom = os.urandom
-except AttributeError:
-    urandom = get_random_bytes
-
 from Crypto.Random import random as pycrypto_random
 import random as stdlib_random
 
@@ -125,7 +119,7 @@ class Benchmark:
             return self.__random_data
 
     def _random_bytes(self, b):
-        return urandom(b)
+        return os.urandom(b)
 
     def announce_start(self, test_name):
         sys.stdout.write("%s: " % (test_name,))


### PR DESCRIPTION
A couple of things missed in https://github.com/Legrandin/pycryptodome/commit/2d2f8bf85a7d09fdc6eeef5ff8e451d689f4e5e9.

Also fix a typo and update some URL redirects.