### PR TITLE
Fix some typos

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -357,7 +357,7 @@ New features
 ------------
 
 * Windows wheels bundle the MPIR library
-* Detection of faults occuring during secret RSA operations
+* Detection of faults occurring during secret RSA operations
 * Detection of non-prime (weak) q value in DSA domain parameters
 * Added original Keccak hash family (b=1600 only).
   In the process, simplified the C code base for SHA-3.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -17,7 +17,7 @@ import sys, os
 sys.path.insert(0, os.path.abspath('../lib'))
 print sys.path
 
-# Mock existance of native modules
+# Mock existence of native modules
 from Crypto.Util import _raw_api
 
 class MockLib(object):

--- a/Doc/src/examples.rst
+++ b/Doc/src/examples.rst
@@ -72,7 +72,7 @@ The following code reads the private RSA key back in, and then prints again the 
 Generate public key and private key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following code generates public key stored in ``receiver.pem`` and private key stored in ``private.pem``. These files will be used in the examples below. Everytime, it generates different public key and private key pair.
+The following code generates public key stored in ``receiver.pem`` and private key stored in ``private.pem``. These files will be used in the examples below. Every time, it generates different public key and private key pair.
 
 .. code-block:: python
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
 
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 

--- a/setup.py
+++ b/setup.py
@@ -727,7 +727,7 @@ if use_separate_namespace:
         create_cryptodome_lib()
 
 
-# By doing this we neeed to change version information in a single file
+# By doing this we need to change version information in a single file
 with open(os.path.join("lib", package_root, "__init__.py")) as init_root:
     for line in init_root:
         if line.startswith("version_info"):

--- a/src/common.h
+++ b/src/common.h
@@ -162,7 +162,7 @@ static inline void align_free(void *mem)
 #endif
 
 /*
- * Endianess convesion
+ * Endianness convesion
  */
 
 static inline void u32to8_little(uint8_t *p, const uint32_t *w)

--- a/src/ghash_clmul.c
+++ b/src/ghash_clmul.c
@@ -85,7 +85,7 @@ FAKE_INIT(ghash_clmul)
 
 struct exp_key {
     /**
-     *  Powers of H (already swapped in byte endianess, and pre-multiplied by X)
+     *  Powers of H (already swapped in byte endianness, and pre-multiplied by X)
      *
      *  h[0] is x*H   mod p(x)
      *  h[1] is x*H^2 mod p(x)

--- a/src/multiply_32.c
+++ b/src/multiply_32.c
@@ -47,19 +47,19 @@ DAMAGE.
 #elif defined(PYCRYPTO_BIG_ENDIAN) 
 #define INDEX(x, i) (((x) + (i)) ^ 1)
 #else
-#error Undefined endianess
+#error Undefined endianness
 #endif
 
 /*
  * Multiply a vector a[] by a scalar b. Add the result into vector t[],
  * starting from index offset.
  *
- * t[] and a[] are little-endian but words are interleaved in big endian systems.
- * In other words, while in little endian systems they are layed out as:
+ * t[] and a[] are little-endian but words are interleaved in big-endian systems.
+ * In other words, while in little-endian systems they are laid out as:
  *
  *   t[0], t[1], t[2], t[3], ...
  *
- * In a big endian system they are instead:
+ * In a big-endian system they are instead:
  *
  *   t[1], t[0], t[3], t[2], t[5], t[4], ...
  *
@@ -192,12 +192,12 @@ size_t addmul128(uint64_t * RESTRICT t, const uint64_t * RESTRICT a, uint64_t b0
 /*
  * Square a vector a[] and store the result in t[].
  *
- * Words in t[] and a[] are interleaved in big endian systems.
- * In other words, while in little endian systems they are layed out as:
+ * Words in t[] and a[] are interleaved in big-endian systems.
+ * In other words, while in little-endian systems they are laid out as:
  *   
  *   t[0], t[1], t[2], t[3], ...
  *
- * In a big endian system they are instead:
+ * In a big-endian system they are instead:
  *
  *   t[1], t[0], t[3], t[2], t[5], t[4], ...
  *


### PR DESCRIPTION
Found using https://github.com/codespell-project/codespell.

There are also some in these files, but are they vendored, external files?

```
./lib/Crypto/PublicKey/RSA.py:169: occured  ==> occurred
./lib/Crypto/PublicKey/ECC.py:694: distiction  ==> distinction
./lib/Crypto/PublicKey/ECC.py:771: distiction  ==> distinction
./lib/Crypto/Util/py3compat.py:83: Pyton  ==> Python
./lib/Crypto/Util/py3compat.py:130: Pyton  ==> Python
./lib/Crypto/Util/number.py:155: definitly  ==> definitely
./lib/Crypto/Util/number.py:157: definitly  ==> definitely
./lib/Crypto/Util/number.py:279: canidate  ==> candidate
./lib/Crypto/Util/number.py:288: Couln't  ==> Couldn't
./lib/Crypto/Util/number.py:329: Couln't  ==> Couldn't
./lib/Crypto/Signature/pkcs1_15.py:207: algorith  ==> algorithm
./lib/Crypto/Signature/pss.py:57: lenth  ==> length
./lib/Crypto/Signature/pss.py:210: lenth  ==> length
./lib/Crypto/Signature/pss.py:274: lenth  ==> length
./lib/Crypto/Hash/HMAC.py:128: Syncronize  ==> Synchronize
./lib/Crypto/SelfTest/IO/test_PKCS8.py:371: ENCRYTION  ==> ENCRYPTION
./lib/Crypto/SelfTest/Cipher/test_SIV.py:345: sequece  ==> sequence
./lib/Crypto/SelfTest/Protocol/test_SecretSharing.py:88: encondings  ==> encodings
./lib/Crypto/Cipher/PKCS1_v1_5.py:144: plausable  ==> plausible
./lib/Crypto/Cipher/_mode_cbc.py:150: lenght  ==> length
./lib/Crypto/Cipher/PKCS1_OAEP.py:49: lenth  ==> length
./lib/Crypto/Cipher/PKCS1_OAEP.py:221: lenth  ==> length
./lib/Crypto/Protocol/KDF.py:132: exlusive  ==> exclusive
./lib/Crypto/Math/_Numbers_gmp.py:254: Endianess  ==> Endianness
./lib/Crypto/Math/_Numbers_gmp.py:277: Endianess  ==> Endianness
./lib/Crypto/Random/random.py:93: seqence  ==> sequence
./Doc/src/cipher/classic.rst:366: invokation  ==> invocation
./Doc/src/cipher/des3.rst:15: indipendent  ==> independent
./src/libtom/tomcrypt_math.h:67: upto  ==> up to
./src/libtom/tomcrypt_math.h:68: succcess  ==> success
./src/libtom/tomcrypt_math.h:73: upto  ==> up to
./src/libtom/tomcrypt_math.h:100: upto  ==> up to
./src/libtom/tomcrypt_math.h:176: upto  ==> up to
./src/libtom/tomcrypt_math.h:192: upto  ==> up to
./src/libtom/tomcrypt_math.h:200: upto  ==> up to
./src/libtom/tomcrypt_math.h:208: upto  ==> up to
./src/libtom/tomcrypt_math.h:239: upto  ==> up to
./src/libtom/tomcrypt_cipher.h:270: endianess  ==> endianness
./src/libtom/tomcrypt_cfg.h:3: inlcude  ==> include
./src/libtom/tomcrypt_cfg.h:51: endianess  ==> endianness
./src/libtom/tomcrypt_cfg.h:124: endianess  ==> endianness
```