### PR TITLE
Drop support for EOL Python 2.6 and 3.0-3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: python
 dist: trusty
 sudo: required
 python:
- - "2.6"
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
@@ -20,10 +18,6 @@ matrix:
  - python: pypy3
    env: CFFI=no
  include:
- - python: 3.4
-   env: CFFI=no OLDPY=python3.2
- - python: 3.4
-   env: CFFI=yes OLDPY=python3.2
  - python: 3.7
    env: CFFI=no
    dist: xenial

--- a/Doc/src/contribute_support.rst
+++ b/Doc/src/contribute_support.rst
@@ -17,11 +17,11 @@ Contribute and support
 
 - Provide tests (in ``Crypto.SelfTest``) along with code. If you fix a bug
   add a test that fails in the current version and passes with your change.
-- If your change breaks backward compatibility, hightlight it and include
+- If your change breaks backward compatibility, highlight it and include
   a justification.
 - Ensure that your code complies to `PEP8`_ and `PEP257`_.
 - Ensure that your code does not use constructs or includes modules not
-  present in `Python 2.4`_.
+  present in `Python 2.6`_.
 - Add a short summary of the change to the file ``Changelog.rst``.
 - Add your name to the list of contributors in the file ``AUTHORS.rst``.
 
@@ -30,10 +30,10 @@ You can mail any comment or question to *pycryptodome@googlegroups.com*.
 
 Bug reports can be filed on the `GitHub tracker <https://github.com/Legrandin/pycryptodome/issues>`_.
 
-.. _BSD 2-clause license: http://opensource.org/licenses/BSD-2-Clause
+.. _BSD 2-clause license: https://opensource.org/licenses/BSD-2-Clause
 .. _GitHub: https://github.com/Legrandin/pycryptodome
-.. _pull request: https://help.github.com/articles/using-pull-requests
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
-.. _MIT license: http://opensource.org/licenses/MIT
-.. _PEP257: http://legacy.python.org/dev/peps/pep-0257/
-.. _Python 2.4: http://rgruet.free.fr/PQR24/PQR2.4.html
+.. _pull request: https://help.github.com/articles/about-pull-requests/
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _MIT license: https://opensource.org/licenses/MIT
+.. _PEP257: https://legacy.python.org/dev/peps/pep-0257/
+.. _Python 2.6: https://rgruet.free.fr/PQR26/PQR2.6.html

--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -92,8 +92,8 @@ class RsaKey(object):
         """
 
         input_set = set(kwargs.keys())
-        public_set = set(('n', 'e'))
-        private_set = public_set | set(('p', 'q', 'd', 'u'))
+        public_set = {'n', 'e'}
+        private_set = public_set | {'p', 'q', 'd', 'u'}
         if input_set not in (private_set, public_set):
             raise ValueError("Some RSA components are missing")
         for component, value in kwargs.items():
@@ -223,7 +223,7 @@ class RsaKey(object):
             key_type = "Private"
         else:
             key_type = "Public"
-        return "%s RSA key at 0x%X" % (key_type, id(self))
+        return "{} RSA key at 0x{:X}".format(key_type, id(self))
 
     def export_key(self, format='PEM', passphrase=None, pkcs=1,
                    protection=None, randfunc=None):

--- a/lib/Crypto/Random/random.py
+++ b/lib/Crypto/Random/random.py
@@ -70,7 +70,7 @@ class StrongRandom(object):
         if num_choices < 0:
             num_choices = 0
         if num_choices < 1:
-            raise ValueError("empty range for randrange(%r, %r, %r)" % (start, stop, step))
+            raise ValueError("empty range for randrange({!r}, {!r}, {!r})".format(start, stop, step))
 
         # Pick a random number in the range of possible numbers
         r = num_choices

--- a/lib/Crypto/SelfTest/Cipher/common.py
+++ b/lib/Crypto/SelfTest/Cipher/common.py
@@ -147,8 +147,8 @@ class CipherStreamingSelfTest(CipherSelfTest):
     def shortDescription(self):
         desc = self.module_name
         if self.mode is not None:
-            desc += " in %s mode" % (self.mode_name,)
-        return "%s should behave like a stream cipher" % (desc,)
+            desc += " in {} mode".format(self.mode_name)
+        return "{} should behave like a stream cipher".format(desc)
 
     def runTest(self):
         plaintext = a2b_hex(self.plaintext)
@@ -185,7 +185,7 @@ class RoundtripTest(unittest.TestCase):
         self.module_name = params.get('module_name', None)
 
     def shortDescription(self):
-        return """%s .decrypt() output of .encrypt() should not be garbled""" % (self.module_name,)
+        return """{} .decrypt() output of .encrypt() should not be garbled""".format(self.module_name)
 
     def runTest(self):
 
@@ -423,9 +423,9 @@ def make_block_tests(module, module_name, test_data, additional_params=dict()):
         if p_description is not None:
             description = p_description
         elif p_mode == 'ECB' and not p2:
-            description = "p=%s, k=%s" % (p_plaintext, p_key)
+            description = "p={}, k={}".format(p_plaintext, p_key)
         else:
-            description = "p=%s, k=%s, %r" % (p_plaintext, p_key, p2)
+            description = "p={}, k={}, {!r}".format(p_plaintext, p_key, p2)
         name = "%s #%d: %s" % (module_name, i+1, description)
         params['description'] = name
         params['module_name'] = module_name
@@ -474,9 +474,9 @@ def make_stream_tests(module, module_name, test_data):
         if p_description is not None:
             description = p_description
         elif not p2:
-            description = "p=%s, k=%s" % (p_plaintext, p_key)
+            description = "p={}, k={}".format(p_plaintext, p_key)
         else:
-            description = "p=%s, k=%s, %r" % (p_plaintext, p_key, p2)
+            description = "p={}, k={}, {!r}".format(p_plaintext, p_key, p2)
         name = "%s #%d: %s" % (module_name, i+1, description)
         params['description'] = name
         params['module_name'] = module_name

--- a/lib/Crypto/SelfTest/Cipher/test_AES.py
+++ b/lib/Crypto/SelfTest/Cipher/test_AES.py
@@ -1260,7 +1260,7 @@ class TestMultipleBlocks(unittest.TestCase):
             cipher = AES.new(key, AES.MODE_ECB, use_aesni=self.use_aesni)
             h = SHA256.new()
 
-            pt = b"".join([ tobytes('{0:016x}'.format(x)) for x in range(20) ])
+            pt = b"".join([ tobytes('{:016x}'.format(x)) for x in range(20) ])
             ct = cipher.encrypt(pt)
             self.assertEqual(SHA256.new(ct).hexdigest(), expected)
 

--- a/lib/Crypto/SelfTest/Cipher/test_DES3.py
+++ b/lib/Crypto/SelfTest/Cipher/test_DES3.py
@@ -71,7 +71,7 @@ for tdes_file in nist_tdes_mmt_files:
         test_data_item = (tostr(hexlify(tv.plaintext)),
                           tostr(hexlify(tv.ciphertext)),
                           tostr(hexlify(key)),
-                          "%s (%s)" % (tdes_file, index))
+                          "{} ({})".format(tdes_file, index))
         test_data.append(test_data_item)
 
 

--- a/lib/Crypto/SelfTest/Cipher/test_EAX.py
+++ b/lib/Crypto/SelfTest/Cipher/test_EAX.py
@@ -622,7 +622,7 @@ class TestVectorsWycheproof(unittest.TestCase):
     def warn(self, tv):
         if tv.warning and self._wycheproof_warnings:
             import warnings
-            warnings.warn("Wycheproof warning: %s (%s)" % (self._id, tv.comment))
+            warnings.warn("Wycheproof warning: {} ({})".format(self._id, tv.comment))
 
     def test_encrypt(self, tv):
         self._id = "Wycheproof Encrypt EAX Test #" + str(tv.id)

--- a/lib/Crypto/SelfTest/Cipher/test_GCM.py
+++ b/lib/Crypto/SelfTest/Cipher/test_GCM.py
@@ -862,7 +862,7 @@ class TestVariableLength(unittest.TestCase):
         h = SHA256.new()
 
         for length in range(160):
-            nonce = '{0:04d}'.format(length).encode('utf-8')
+            nonce = '{:04d}'.format(length).encode('utf-8')
             data = bchr(length) * length
             cipher = AES.new(key, AES.MODE_GCM, nonce=nonce, **self._extra_params)
             ct, tag = cipher.encrypt_and_digest(data)

--- a/lib/Crypto/SelfTest/Hash/common.py
+++ b/lib/Crypto/SelfTest/Hash/common.py
@@ -268,9 +268,7 @@ def make_hash_tests(module, module_name, test_data, digest_size, oid=None,
         tests.append(HashTestOID(module, oid, extra_params))
 
     tests.append(ByteArrayTest(module, extra_params))
-
-    if not (sys.version_info[0] == 2 and sys.version_info[1] < 7):
-        tests.append(MemoryViewTest(module, extra_params))
+    tests.append(MemoryViewTest(module, extra_params))
 
     return tests
 

--- a/lib/Crypto/SelfTest/Hash/test_CMAC.py
+++ b/lib/Crypto/SelfTest/Hash/test_CMAC.py
@@ -374,7 +374,7 @@ class TestVectorsWycheproof(unittest.TestCase):
     def warn(self, tv):
         if tv.warning and self._wycheproof_warnings:
             import warnings
-            warnings.warn("Wycheproof warning: %s (%s)" % (self._id, tv.comment))
+            warnings.warn("Wycheproof warning: {} ({})".format(self._id, tv.comment))
 
     def test_create_mac(self, tv):
         self._id = "Wycheproof MAC creation Test #" + str(tv.id)

--- a/lib/Crypto/SelfTest/loader.py
+++ b/lib/Crypto/SelfTest/loader.py
@@ -113,7 +113,7 @@ def load_tests(dir_comps, file_name, description, conversions):
     For a group of lines, the object has one attribute per line.
     """
     
-    description = "%s test (%s)" % (description, file_name)
+    description = "{} test ({})".format(description, file_name)
 
     with open(pycryptodome_filename(dir_comps, file_name)) as file_in:
         results = _load_tests(dir_comps, file_in, description, conversions)

--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -35,8 +35,7 @@ from Crypto.Util._file_system import pycryptodome_filename
 #
 # List of file suffixes for Python extensions
 #
-if sys.version_info[0] < 3 or \
-   (sys.version_info[0] == 3 and sys.version_info[1] <= 3):
+if sys.version_info.major == 2:
 
     import imp
     extension_suffixes = []
@@ -50,10 +49,7 @@ else:
     extension_suffixes = machinery.EXTENSION_SUFFIXES
 
 # Which types with buffer interface we support (apart from byte strings)
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    _buffer_type = (bytearray)
-else:
-    _buffer_type = (bytearray, memoryview)
+_buffer_type = (bytearray, memoryview)
 
 try:
     from cffi import FFI
@@ -150,12 +146,7 @@ except ImportError:
 
     # ---- Get raw pointer ---
 
-    if sys.version_info[0] == 2 and sys.version_info[1] == 6:
-        # ctypes in 2.6 does not define c_ssize_t. Replacing it
-        # with c_size_t keeps the structure correctely laid out
-        _c_ssize_t = c_size_t
-    else:
-        _c_ssize_t = ctypes.c_ssize_t
+    _c_ssize_t = ctypes.c_ssize_t
 
     _PyBUF_SIMPLE = 0
     _PyObject_GetBuffer = ctypes.pythonapi.PyObject_GetBuffer

--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -245,8 +245,8 @@ def load_pycryptodome_raw_lib(name, cdecl):
             return load_lib(pycryptodome_filename(dir_comps, filename),
                             cdecl)
         except OSError as exp:
-            attempts.append("Trying '%s': %s" % (filename, str(exp)))
-    raise OSError("Cannot load native module '%s': %s" % (name, ", ".join(attempts)))
+            attempts.append("Trying '{}': {}".format(filename, str(exp)))
+    raise OSError("Cannot load native module '{}': {}".format(name, ", ".join(attempts)))
 
 def expect_byte_string(data):
     raise NotImplementedError("To be removed")

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -85,11 +85,7 @@ if sys.version_info[0] == 2:
 
     from sys import maxint
 
-    if sys.version_info[1] < 7:
-        import types
-        _memoryview = types.NoneType
-    else:
-        _memoryview = memoryview
+    _memoryview = memoryview
 else:
     def b(s):
        return s.encode("latin-1") # utf-8 would cause some side-effects we don't want
@@ -115,19 +111,12 @@ else:
     def byte_string(s):
         return isinstance(s, bytes)
 
-    # With Python 3.[0-2], unhexlify only accepts bytes.
-    # Starting from Python 3.3, strings can be passed too.
     import binascii
     hexlify = binascii.hexlify
-    if sys.version_info[1] <= 2:
-        _unhexlify = binascii.unhexlify
-        def unhexlify(x):
-            return _unhexlify(tobytes(x))
-    else:
-        unhexlify = binascii.unhexlify
+    unhexlify = binascii.unhexlify
     del binascii
 
-    # In Pyton 3.x, StringIO is a sub-module of io
+    # In Python 3.x, StringIO is a sub-module of io
     from io import BytesIO
     from sys import maxsize as maxint
 

--- a/pct-speedtest.py
+++ b/pct-speedtest.py
@@ -59,12 +59,6 @@ try:
 except ImportError: # Some builds/versions of Python don't have a hashlib module
     hashlib = hmac = None
 
-# os.urandom() is less noisy when profiling, but it doesn't exist in Python < 2.4
-try:
-    urandom = os.urandom
-except AttributeError:
-    urandom = get_random_bytes
-
 from Crypto.Random import random as pycrypto_random
 import random as stdlib_random
 
@@ -125,7 +119,7 @@ class Benchmark:
             return self.__random_data
 
     def _random_bytes(self, b):
-        return urandom(b)
+        return os.urandom(b)
 
     def announce_start(self, test_name):
         sys.stdout.write("%s: " % (test_name,))

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ def test_compilation(program, extra_cc_options=None, extra_libraries=None, msg='
             x = ""
         else:
             x = " not"
-        PrintErr("Target does%s support %s" % (x, msg))
+        PrintErr("Target does{} support {}".format(x, msg))
 
     return result
 
@@ -470,7 +470,7 @@ def create_cryptodome_lib():
             full_file_name_src = os.path.join(root_src, file_name)
             full_file_name_dst = os.path.join(root_dst, file_name)
 
-            PrintErr("Copying file %s to %s" % (full_file_name_src, full_file_name_dst))
+            PrintErr("Copying file {} to {}".format(full_file_name_src, full_file_name_dst))
             shutil.copy2(full_file_name_src, full_file_name_dst)
 
             if not full_file_name_dst.endswith(".py"):

--- a/setup.py
+++ b/setup.py
@@ -25,20 +25,15 @@ try:
 except ImportError:
     from distutils.core import Extension, Command, setup
 from distutils.command.build_ext import build_ext
-from distutils.command.build import build
 from distutils.errors import CCompilerError
 from distutils import ccompiler
 import distutils
-import platform
 import re
 import os
 import sys
 import shutil
 import struct
-if sys.version_info[0:2] == (2, 6):
-    from distutils import sysconfig
-else:
-    import sysconfig
+import sysconfig
 
 # Monkey patch for https://bugs.python.org/issue34108
 if sys.version_info[0:3] == (3, 7, 0) and os.name == 'nt':
@@ -69,7 +64,7 @@ PyCryptodome
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
 
-It supports Python 2.6 or newer, all Python 3 versions and PyPy.
+It supports Python 2.7, Python 3.4 or newer and PyPy.
 
 You can install it with::
 
@@ -736,16 +731,17 @@ with open(os.path.join("lib", package_root, "__init__.py")) as init_root:
 version_string = ".".join([str(x) for x in version_tuple])
 
 setup(
-    name = project_name,
-    version = version_string,
-    description = "Cryptographic library for Python",
-    long_description = longdesc,
-    author = "Helder Eijs",
-    author_email = "helderijs@gmail.com",
-    url = "http://www.pycryptodome.org",
-    platforms = 'Posix; MacOS X; Windows',
-    zip_safe = False,
-    classifiers = [
+    name=project_name,
+    version=version_string,
+    description="Cryptographic library for Python",
+    long_description=longdesc,
+    author="Helder Eijs",
+    author_email="helderijs@gmail.com",
+    url="https://www.pycryptodome.org",
+    platforms='Posix; MacOS X; Windows',
+    zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',
         'License :: Public Domain',
@@ -755,17 +751,20 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Topic :: Security :: Cryptography',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
-    packages = packages,
-    package_dir = package_dir,
-    package_data = package_data,
-    cmdclass = {
+    packages=packages,
+    package_dir=package_dir,
+    package_data=package_data,
+    cmdclass={
         'build_ext':PCTBuildExt,
         'build_py': PCTBuildPy,
         'test': TestCommand,
         },
-    ext_modules = ext_modules,
+    ext_modules=ext_modules,
 )


### PR DESCRIPTION
Python 2.6 and 3.0-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

<img src=https://user-images.githubusercontent.com/1324225/45940708-3f94d500-bfe3-11e8-8786-bb3c166cdd55.png width=70%>

They're also little used.

Here's the pip installs for pycryptodome from PyPI for August 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  47.02% |        453,176 |
| 3.6            |  34.38% |        331,425 |
| 3.5            |  12.37% |        119,208 |
| 3.7            |   3.35% |         32,306 |
| 3.4            |   2.68% |         25,803 |
| 2.6            |   0.16% |          1,551 |
| 3.8            |   0.02% |            206 |
| 3.3            |   0.02% |            164 |
| 3.2            |   0.00% |             31 |
| None           |   0.00% |              1 |
| Total          |         |        963,871 |

Source: `pypinfo --start-date 2018-08-01 --end-date 2018-08-31 --percent --markdown pycryptodome pyversion`

Finally, Python 2.6 is failing the build as dependencies no longer support it.

Dropping support means old crutch code can be removed, modern features of Python can be used, the CI is quicker and passes.
