### PR TITLE
Drop support for EOL Python 3.0-3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 python:
  - "2.6"
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
@@ -20,10 +19,6 @@ matrix:
  - python: pypy3
    env: CFFI=no
  include:
- - python: 3.4
-   env: CFFI=no OLDPY=python3.2
- - python: 3.4
-   env: CFFI=yes OLDPY=python3.2
  - python: 3.7
    env: CFFI=no
    dist: xenial

--- a/Doc/src/contribute_support.rst
+++ b/Doc/src/contribute_support.rst
@@ -17,11 +17,11 @@ Contribute and support
 
 - Provide tests (in ``Crypto.SelfTest``) along with code. If you fix a bug
   add a test that fails in the current version and passes with your change.
-- If your change breaks backward compatibility, hightlight it and include
+- If your change breaks backward compatibility, highlight it and include
   a justification.
 - Ensure that your code complies to `PEP8`_ and `PEP257`_.
 - Ensure that your code does not use constructs or includes modules not
-  present in `Python 2.4`_.
+  present in `Python 2.6`_.
 - Add a short summary of the change to the file ``Changelog.rst``.
 - Add your name to the list of contributors in the file ``AUTHORS.rst``.
 
@@ -30,10 +30,10 @@ You can mail any comment or question to *pycryptodome@googlegroups.com*.
 
 Bug reports can be filed on the `GitHub tracker <https://github.com/Legrandin/pycryptodome/issues>`_.
 
-.. _BSD 2-clause license: http://opensource.org/licenses/BSD-2-Clause
+.. _BSD 2-clause license: https://opensource.org/licenses/BSD-2-Clause
 .. _GitHub: https://github.com/Legrandin/pycryptodome
-.. _pull request: https://help.github.com/articles/using-pull-requests
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
-.. _MIT license: http://opensource.org/licenses/MIT
-.. _PEP257: http://legacy.python.org/dev/peps/pep-0257/
-.. _Python 2.4: http://rgruet.free.fr/PQR24/PQR2.4.html
+.. _pull request: https://help.github.com/articles/about-pull-requests/
+.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _MIT license: https://opensource.org/licenses/MIT
+.. _PEP257: https://legacy.python.org/dev/peps/pep-0257/
+.. _Python 2.6: https://rgruet.free.fr/PQR26/PQR2.6.html

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ PyCryptodome
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
 
-It supports Python 2.6 or newer, all Python 3 versions and PyPy.
+It supports Python 2.6 and 2.7, Python 3.4 and newer, and PyPy.
 
 The installation procedure depends on the package you want the library to be in.
 PyCryptodome can be used as:

--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -35,8 +35,7 @@ from Crypto.Util._file_system import pycryptodome_filename
 #
 # List of file suffixes for Python extensions
 #
-if sys.version_info[0] < 3 or \
-   (sys.version_info[0] == 3 and sys.version_info[1] <= 3):
+if sys.version_info[0] < 3:
 
     import imp
     extension_suffixes = []
@@ -180,7 +179,7 @@ except ImportError:
         ]
 
         # Extra field for CPython 2.6/2.7
-        if sys.version_info[0] == 2 or (sys.version_info[0] == 3 and sys.version_info[1] <= 2):
+        if sys.version_info[0] == 2:
             _fields_.insert(-1, ('smalltable', _c_ssize_t * 2))
 
     def c_uint8_ptr(data):

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -115,19 +115,12 @@ else:
     def byte_string(s):
         return isinstance(s, bytes)
 
-    # With Python 3.[0-2], unhexlify only accepts bytes.
-    # Starting from Python 3.3, strings can be passed too.
     import binascii
     hexlify = binascii.hexlify
-    if sys.version_info[1] <= 2:
-        _unhexlify = binascii.unhexlify
-        def unhexlify(x):
-            return _unhexlify(tobytes(x))
-    else:
-        unhexlify = binascii.unhexlify
+    unhexlify = binascii.unhexlify
     del binascii
 
-    # In Pyton 3.x, StringIO is a sub-module of io
+    # In Python 3.x, StringIO is a sub-module of io
     from io import BytesIO
     from sys import maxsize as maxint
 

--- a/pct-speedtest.py
+++ b/pct-speedtest.py
@@ -59,12 +59,6 @@ try:
 except ImportError: # Some builds/versions of Python don't have a hashlib module
     hashlib = hmac = None
 
-# os.urandom() is less noisy when profiling, but it doesn't exist in Python < 2.4
-try:
-    urandom = os.urandom
-except AttributeError:
-    urandom = get_random_bytes
-
 from Crypto.Random import random as pycrypto_random
 import random as stdlib_random
 
@@ -125,7 +119,7 @@ class Benchmark:
             return self.__random_data
 
     def _random_bytes(self, b):
-        return urandom(b)
+        return os.urandom(b)
 
     def announce_start(self, test_name):
         sys.stdout.write("%s: " % (test_name,))

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,9 @@ try:
 except ImportError:
     from distutils.core import Extension, Command, setup
 from distutils.command.build_ext import build_ext
-from distutils.command.build import build
 from distutils.errors import CCompilerError
 from distutils import ccompiler
 import distutils
-import platform
 import re
 import os
 import sys
@@ -69,7 +67,7 @@ PyCryptodome
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
 
-It supports Python 2.6 or newer, all Python 3 versions and PyPy.
+It supports Python 2.6 and 2.7, Python 3.4 and newer, and PyPy.
 
 You can install it with::
 
@@ -736,16 +734,17 @@ with open(os.path.join("lib", package_root, "__init__.py")) as init_root:
 version_string = ".".join([str(x) for x in version_tuple])
 
 setup(
-    name = project_name,
-    version = version_string,
-    description = "Cryptographic library for Python",
-    long_description = longdesc,
-    author = "Helder Eijs",
-    author_email = "helderijs@gmail.com",
-    url = "http://www.pycryptodome.org",
-    platforms = 'Posix; MacOS X; Windows',
-    zip_safe = False,
-    classifiers = [
+    name=project_name,
+    version=version_string,
+    description="Cryptographic library for Python",
+    long_description=longdesc,
+    author="Helder Eijs",
+    author_email="helderijs@gmail.com",
+    url="https://www.pycryptodome.org",
+    platforms='Posix; MacOS X; Windows',
+    zip_safe=False,
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: BSD License',
         'License :: Public Domain',
@@ -758,14 +757,18 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
-    packages = packages,
-    package_dir = package_dir,
-    package_data = package_data,
-    cmdclass = {
+    packages=packages,
+    package_dir=package_dir,
+    package_data=package_data,
+    cmdclass={
         'build_ext':PCTBuildExt,
         'build_py': PCTBuildPy,
         'test': TestCommand,
         },
-    ext_modules = ext_modules,
+    ext_modules=ext_modules,
 )


### PR DESCRIPTION
Subset of #212.

Python 3.0-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

<img src=https://user-images.githubusercontent.com/1324225/45940708-3f94d500-bfe3-11e8-8786-bb3c166cdd55.png width=70%>

They're also little used.

Here's the pip installs for pycryptodome from PyPI for August 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  47.02% |        453,176 |
| 3.6            |  34.38% |        331,425 |
| 3.5            |  12.37% |        119,208 |
| 3.7            |   3.35% |         32,306 |
| 3.4            |   2.68% |         25,803 |
| 2.6            |   0.16% |          1,551 |
| 3.8            |   0.02% |            206 |
| 3.3            |   0.02% |            164 |
| 3.2            |   0.00% |             31 |
| None           |   0.00% |              1 |
| Total          |         |        963,871 |

Source: `pypinfo --start-date 2018-08-01 --end-date 2018-08-31 --percent --markdown pycryptodome pyversion`

Dropping support means old crutch code can be removed, modern features of Python can be used, the CI is quicker and passes.