### PR TITLE
fix small issue in the signer example code

### DIFF
--- a/Doc/src/public_key/dsa.rst
+++ b/Doc/src/public_key/dsa.rst
@@ -48,7 +48,7 @@ key in a file called ``public_key.pem``, sign a message (with
     >>> message = b"Hello"
     >>> hash_obj = SHA256.new(message)
     >>> signer = DSS.new(key, 'fips-186-3')
-    >>> signature = key.sign(hash_obj)
+    >>> signature = signer.sign(hash_obj)
     >>> 
     >>> # Load the public key
     >>> f = open("public_key.pem", "r")


### PR DESCRIPTION
Probably a legacy leftover from pycrypto where the signing function was a method under the private key object, in this example we create a signer object but never use it to actually do the signature.