### PR TITLE
Default nonce length set to 12 bytes

### DIFF
--- a/lib/Crypto/Cipher/_mode_gcm.py
+++ b/lib/Crypto/Cipher/_mode_gcm.py
@@ -606,10 +606,10 @@ def _create_gcm_cipher(factory, **kwargs):
         key = kwargs.pop("key")
     except KeyError as e:
         raise TypeError("Missing parameter:" + str(e))
-
+    
     nonce = kwargs.pop("nonce", None)
     if nonce is None:
-        nonce = get_random_bytes(16)
+        nonce = get_random_bytes(12)
     mac_len = kwargs.pop("mac_len", 16)
 
     # Not documented - only used for testing


### PR DESCRIPTION
For AES GCM ciphers the NIST SP800-38D recommends 96 bits, or 12 bytes, of nonce data to improve efficiency and to eliminate the possibility of a GHASH hash collision for nonces with lengths other than than 12 bytes.