### PR TITLE
compiler_opt: Handle msvc/distutils compilation case

### DIFF
--- a/compiler_opt.py
+++ b/compiler_opt.py
@@ -83,7 +83,7 @@ def test_compilation(program, extra_cc_options=None, extra_libraries=None,
         compiler.link_executable(objects, oname, libraries=extra_libraries,
                                  extra_preargs=extra_linker_options)
         result = True
-    except CCompilerError:
+    except (CCompilerError, OSError):
         result = False
     for f in objects + [fname, oname]:
         try:


### PR DESCRIPTION
MSVC9 distutils ccompiler raises WindowsError, which is not
covered.

      File "<string>", line 1, in <module>
      File "c:\users\root\temp\pip-install-armnd4\pycryptodome\setup.py", line 445, in <module>
        set_compiler_options(package_root, ext_modules)
      File "compiler_opt.py", line 325, in set_compiler_options
        cpuid_h_present = compiler_has_cpuid_h()
      File "compiler_opt.py", line 159, in compiler_has_cpuid_h
        return test_compilation(source, msg="cpuid.h header")
      File "compiler_opt.py", line 83, in test_compilation
        extra_preargs=extra_linker_options)
      File "C:\Python27\lib\distutils\ccompiler.py", line 700, in link_executable
        debug, extra_preargs, extra_postargs, None, target_lang)
      File "C:\Python27\lib\distutils\msvc9compiler.py", line 610, in link
        if self._need_link(objects, output_filename):
      File "C:\Python27\lib\distutils\ccompiler.py", line 471, in _need_link
        newer = newer_group (objects, output_file)
      File "C:\Python27\lib\distutils\dep_util.py", line 86, in newer_group
        if os.stat(source)[ST_MTIME] > target_mtime:
    WindowsError: [Error 2] File not found: 'build\\test1.obj'