### PR TITLE
Fix all DeprecationWarning: invalid escape sequence

### DIFF
--- a/lib/Crypto/Cipher/PKCS1_v1_5.py
+++ b/lib/Crypto/Cipher/PKCS1_v1_5.py
@@ -101,7 +101,7 @@ class PKCS115_Cipher:
         return c
 
     def decrypt(self, ciphertext, sentinel):
-        """Decrypt a PKCS#1 v1.5 ciphertext.
+        r"""Decrypt a PKCS#1 v1.5 ciphertext.
 
         This function is named ``RSAES-PKCS1-V1_5-DECRYPT``, and is specified in
         `section 7.2.2 of RFC8017

--- a/lib/Crypto/SelfTest/Hash/common.py
+++ b/lib/Crypto/SelfTest/Hash/common.py
@@ -34,7 +34,7 @@ from Crypto.Util.py3compat import b, tobytes
 from Crypto.Util.strxor import strxor_c
 
 def t2b(hex_string):
-    shorter = re.sub(b'\s+', b'', tobytes(hex_string))
+    shorter = re.sub(br'\s+', b'', tobytes(hex_string))
     return unhexlify(shorter)
 
 

--- a/lib/Crypto/Signature/pss.py
+++ b/lib/Crypto/Signature/pss.py
@@ -190,7 +190,7 @@ def MGF1(mgfSeed, maskLen, hash_gen):
 
 
 def _EMSA_PSS_ENCODE(mhash, emBits, randFunc, mgf, sLen):
-    """
+    r"""
     Implement the ``EMSA-PSS-ENCODE`` function, as defined
     in PKCS#1 v2.1 (RFC3447, 9.1.1).
 

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -198,7 +198,7 @@ def _rabinMillerTest(n, rounds, randfunc=None):
     return 1
 
 def getStrongPrime(N, e=0, false_positive_prob=1e-6, randfunc=None):
-    """
+    r"""
     Return a random strong *N*-bit prime number.
     In this context, *p* is a strong prime if *p-1* and *p+1* have at
     least one large prime factor.


### PR DESCRIPTION
Hello,

This is the last patch for this kind of warnings, they should be all fixed now:
```python
/Util/number.py:227: DeprecationWarning: invalid escape sequence \ 
```
I used this command to track them down:
```shell
python3 -Wall -m compileall -q -f *
```

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>