### PR TITLE
Fix Python 3.8 SyntaxWarning: "is" with a literal

### DIFF
--- a/lib/Crypto/SelfTest/Random/test_random.py
+++ b/lib/Crypto/SelfTest/Random/test_random.py
@@ -100,7 +100,7 @@ class SimpleTest(unittest.TestCase):
         for i in range(10):
             self.assertEqual(random.choice((1,2,3)) in (1,2,3), True)
         self.assertEqual(random.choice([1,2,3]) in [1,2,3], True)
-        if sys.version_info[0] is 3:
+        if sys.version_info[0] == 3:
             self.assertEqual(random.choice(bytearray(b('123'))) in bytearray(b('123')), True)
         self.assertEqual(1, random.choice([1]))
         self.assertRaises(IndexError, random.choice, [])


### PR DESCRIPTION
Fixes this warning from Python 3.8:

```
/usr/lib/python3/dist-packages/Cryptodome/SelfTest/Random/test_random.py:103: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sys.version_info[0] is 3:
```