### PR TITLE
Speed up Shamir secret sharing split and combine

### DIFF
--- a/lib/Crypto/Protocol/SecretSharing.py
+++ b/lib/Crypto/Protocol/SecretSharing.py
@@ -171,7 +171,7 @@ class Shamir(object):
         >>> from binascii import hexlify
         >>> from Crypto.Cipher import AES
         >>> from Crypto.Random import get_random_bytes
-        >>> from Crypto.Protocol.secret_sharing import Shamir
+        >>> from Crypto.Protocol.SecretSharing import Shamir
         >>>
         >>> key = get_random_bytes(16)
         >>> shares = Shamir.split(2, 5, key)
@@ -192,7 +192,7 @@ class Shamir(object):
 
         >>> from binascii import unhexlify
         >>> from Crypto.Cipher import AES
-        >>> from Crypto.Protocol.secret_sharing import Shamir
+        >>> from Crypto.Protocol.SecretSharing import Shamir
         >>>
         >>> shares = []
         >>> for x in range(2):


### PR DESCRIPTION
Made the following 2 changes after running into performance issues with Shamir Secret Sharing:

* For `split`, use [Horner's method](https://en.wikipedia.org/wiki/Horner%27s_method) which uses only a single multiplication by a small number in our case (instead of 2 multiplications including one between two potentially large numbers). For large-ish `k` and `n` this is significant. I tested with `n = 1000` and `k = 666` and `split` now takes 3s instead of 33s on my system. There are faster algorithms for evaluating a polynomial on many points at once but that would require a lot more changes and might not be worth it for smaller parameters.

* For `combine`, separately compute numerator and denominator to avoid expensive modular inverse computations. Doing it this way requires `k` times less inversions. I also removed the `coeff_0_l` and `inv` variables, I can't imagine why they were here in the first place since they just cancel each other. On my system, for `n = 100` and `k = 66`, this brings down computation time from 8s to 300ms (and makes it possible to use `n = 1000`).

I checked that this returns the same shares as before for the same random coefficients (in reverse order).