### PR TITLE
Crypto/SelfTest/Cipher: make sure "id" property exists

### DIFF
--- a/lib/Crypto/SelfTest/Cipher/test_ChaCha20_Poly1305.py
+++ b/lib/Crypto/SelfTest/Cipher/test_ChaCha20_Poly1305.py
@@ -626,6 +626,7 @@ class TestVectorsWycheproof(unittest.TestCase):
     def __init__(self, wycheproof_warnings):
         unittest.TestCase.__init__(self)
         self._wycheproof_warnings = wycheproof_warnings
+        self._id = "None"
 
     def setUp(self):
         comps = "Crypto.SelfTest.Cipher.test_vectors.wycheproof".split(".")

--- a/lib/Crypto/SelfTest/Cipher/test_EAX.py
+++ b/lib/Crypto/SelfTest/Cipher/test_EAX.py
@@ -656,6 +656,7 @@ class TestVectorsWycheproof(unittest.TestCase):
     def __init__(self, wycheproof_warnings):
         unittest.TestCase.__init__(self)
         self._wycheproof_warnings = wycheproof_warnings
+        self._id = "None"
 
     def setUp(self):
         comps = "Crypto.SelfTest.Cipher.test_vectors.wycheproof".split(".")

--- a/lib/Crypto/SelfTest/Cipher/test_GCM.py
+++ b/lib/Crypto/SelfTest/Cipher/test_GCM.py
@@ -828,6 +828,7 @@ class TestVectorsWycheproof(unittest.TestCase):
         unittest.TestCase.__init__(self)
         self._wycheproof_warnings = wycheproof_warnings
         self._extra_params = extra_params
+        self._id = "None"
 
     def setUp(self):
         comps = "Crypto.SelfTest.Cipher.test_vectors.wycheproof".split(".")

--- a/lib/Crypto/SelfTest/Cipher/test_SIV.py
+++ b/lib/Crypto/SelfTest/Cipher/test_SIV.py
@@ -456,6 +456,7 @@ class TestVectorsWycheproof(unittest.TestCase):
 
     def __init__(self):
         unittest.TestCase.__init__(self)
+        self._id = "None"
 
     def setUp(self):
         comps = "Crypto.SelfTest.Cipher.test_vectors.wycheproof".split(".")


### PR DESCRIPTION
Tests are failing because TestVectorsWycheproof sometimes does not have the "id"
property initialized. This was taken from the (working) Hash/test_CMAC.py