### PR TITLE
Changed RSA CRT Coefficient calculation from pInv mod q to qInv mod p

### DIFF
--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -629,7 +629,7 @@ def _import_pkcs1_private(encoded, *kwargs):
     der = DerSequence().decode(encoded, nr_elements=9, only_ints_expected=True)
     if der[0] != 0:
         raise ValueError("No PKCS#1 encoding of an RSA private key")
-    return construct(der[1:6] + [Integer(der[4]).inverse(der[5])])
+    return construct(der[1:6] + [Integer(der[5]).inverse(der[4])])
 
 
 def _import_pkcs1_public(encoded, *kwargs):

--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -702,7 +702,7 @@ def _import_openssh_private_rsa(data, password):
     _, padded = read_string(decrypted)  # Comment
     check_padding(padded)
 
-    build = [Integer.from_bytes(x) for x in (n, e, d, q, p, iqmp)]
+    build = [Integer.from_bytes(x) for x in (n, e, d, p, q, iqmp)]
     return construct(build)
 
 

--- a/lib/Crypto/SelfTest/PublicKey/test_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_RSA.py
@@ -97,7 +97,7 @@ class RSATest(unittest.TestCase):
         # Compute q, d, and u from n, e, and p
         self.q = self.n // self.p
         self.d = inverse(self.e, (self.p-1)*(self.q-1))
-        self.u = inverse(self.p, self.q)    # u = e**-1 (mod q)
+        self.u = inverse(self.q, self.p)    # u = q**-1 (mod p)
 
         self.rsa = RSA
 
@@ -187,7 +187,7 @@ class RSATest(unittest.TestCase):
         self.assertRaises(ValueError, self.rsa.construct, tup)
 
         from Crypto.Util.number import inverse
-        tup = (self.n, self.e, self.d, self.p, self.q, inverse(self.q, self.p))
+        tup = (self.n, self.e, self.d, self.p, self.q, inverse(self.p, self.q))
         self.assertRaises(ValueError, self.rsa.construct, tup)
 
     def test_factoring(self):
@@ -234,7 +234,7 @@ class RSATest(unittest.TestCase):
         self.assertEqual(rsaObj.n, rsaObj.p * rsaObj.q)     # n = pq
         lcm = int(Integer(rsaObj.p-1).lcm(rsaObj.q-1))
         self.assertEqual(1, rsaObj.d * rsaObj.e % lcm) # ed = 1 (mod LCM(p-1, q-1))
-        self.assertEqual(1, rsaObj.p * rsaObj.u % rsaObj.q) # pu = 1 (mod q)
+        self.assertEqual(1, rsaObj.q * rsaObj.u % rsaObj.p) # qu = 1 (mod p)
         self.assertEqual(1, rsaObj.p > 1)   # p > 1
         self.assertEqual(1, rsaObj.q > 1)   # q > 1
         self.assertEqual(1, rsaObj.e > 1)   # e > 1

--- a/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
@@ -289,7 +289,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
 
     ###
     def testExportKey1(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         derKey = key.export_key("DER")
         self.assertEqual(derKey, self.rsaKeyDER)
 
@@ -299,7 +299,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         self.assertEqual(derKey, self.rsaPublicKeyDER)
 
     def testExportKey3(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         pemKey = key.export_key("PEM")
         self.assertEqual(pemKey, b(self.rsaKeyPEM))
 
@@ -316,23 +316,23 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         self.assertEqual(openssh_1[1], openssh_2[1])
 
     def testExportKey7(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         derKey = key.export_key("DER", pkcs=8)
         self.assertEqual(derKey, self.rsaKeyDER8)
 
     def testExportKey8(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         pemKey = key.export_key("PEM", pkcs=8)
         self.assertEqual(pemKey, b(self.rsaKeyPEM8))
 
     def testExportKey9(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         self.assertRaises(ValueError, key.export_key, "invalid-format")
 
     def testExportKey10(self):
         # Export and re-import the encrypted key. It must match.
         # PEM envelope, PKCS#1, old PEM encryption
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         outkey = key.export_key('PEM', 'test')
         self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
         self.failUnless(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
@@ -344,7 +344,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testExportKey11(self):
         # Export and re-import the encrypted key. It must match.
         # PEM envelope, PKCS#1, old PEM encryption
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         outkey = key.export_key('PEM', 'test', pkcs=1)
         self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
         self.failUnless(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
@@ -356,7 +356,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testExportKey12(self):
         # Export and re-import the encrypted key. It must match.
         # PEM envelope, PKCS#8, old PEM encryption
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         outkey = key.export_key('PEM', 'test', pkcs=8)
         self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
         self.failUnless(tostr(outkey).find('BEGIN PRIVATE KEY')!=-1)
@@ -368,7 +368,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testExportKey13(self):
         # Export and re-import the encrypted key. It must match.
         # PEM envelope, PKCS#8, PKCS#8 encryption
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         outkey = key.export_key('PEM', 'test', pkcs=8,
                 protection='PBKDF2WithHMAC-SHA1AndDES-EDE3-CBC')
         self.failUnless(tostr(outkey).find('4,ENCRYPTED')==-1)
@@ -381,7 +381,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testExportKey14(self):
         # Export and re-import the encrypted key. It must match.
         # DER envelope, PKCS#8, PKCS#8 encryption
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         outkey = key.export_key('DER', 'test', pkcs=8)
         inkey = RSA.importKey(outkey, 'test')
         self.assertEqual(key.n, inkey.n)
@@ -391,7 +391,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testExportKey15(self):
         # Verify that that error an condition is detected when trying to
         # use a password with DER encoding and PKCS#1.
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         self.assertRaises(ValueError, key.export_key, 'DER', 'test', 1)
 
     def test_import_key(self):
@@ -402,7 +402,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         self.assertEqual(key.e, self.e)
 
     def test_exportKey(self):
-        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
+        key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.qInv])
         self.assertEqual(key.export_key(), key.exportKey())
 
 


### PR DESCRIPTION
Started discussion on issue #361 . Let me know where discussion would be best continued.

Most RSA implementations (see openssl [rsa_sp800_56b_gen.c:236](https://github.com/openssl/openssl/blob/651101e18d66b2ae89851ce8906299e9d2a871e0/crypto/rsa/rsa_sp800_56b_gen.c) and [rsa_sp800_56b_check.c:62](https://github.com/openssl/openssl/blob/79c44b4e3044aee9dc9618850d4f1ce067757b4b/crypto/rsa/rsa_sp800_56b_check.c)) / RSA reference material (see [PKCS#1 spec:page 56](https://tools.ietf.org/html/rfc8017), [reference 1](https://www.di-mgt.com.au/crt_rsa.html), [reference 2](https://en.wikipedia.org/wiki/RSA_(cryptosystem)#Using_the_Chinese_remainder_algorithm)) calculate the Chinese Remainder Theorem (CRT) coefficient, represented as the variable `u` in pycryptodome, as `q^-1 mod p` or `q.inverse(p)`, but pycryptodome calculates it as `p^-1 mod q` or `p.inverse(q)` (see [RSA.py:467](https://github.com/Legrandin/pycryptodome/blob/cc46c9f516ac6e7e5a629d60ed282917025926f1/lib/Crypto/PublicKey/RSA.py)).

This PR changes the calculation of the CRT coefficient `u` and swaps some of the decryption / verification logic involving this value. It should be logically identical to the previous version, but more compatible / sensical compared to other implementations (ie. OpenSSL). Similarly, I changed the current RSA tests to account for the change -- previous versions will fail these new tests.