### PR TITLE
Fix macOS SDK path for notarization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
    after_success: true
  - os: osx
    env: PYCRYPTODOME_DEBUG=1
-   env: CFLAGS=" -isysroot $(xcrun --show-sdk-path)"
+   env: CFLAGS=" -isysroot $(xcrun --sdk macosx --show-sdk-path)"
    language: generic
    install: pip2 install cibuildwheel==1.1.0
    after_success: travis/travis_after_success_osx.sh


### PR DESCRIPTION
Resolves #381.

I ran a test build using my own Travis account, and the `clang` invocations *suggest* the issue is fixed. But the best way to actually test would be to invoke `otool` on the built artifacts. Is there an existing place that builds get pushed, or should I temporarily add Travis artifact uploading to the script?