### PR TITLE
README: Use HTTPS for homepage link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,6 @@ For more information, see the `homepage`_.
 
 All the code can be downloaded from `GitHub`_.
 
-.. _`homepage`: http://www.pycryptodome.org
+.. _`homepage`: https://www.pycryptodome.org
 .. _`GMP`: https://gmplib.org
 .. _GitHub: https://github.com/Legrandin/pycryptodome


### PR DESCRIPTION
The README was using an insecure `http` URL for its homepage link; this PR makes it use `https` instead.