### PR TITLE
3DES cipher: correct the key length documentation

### DIFF
--- a/lib/Crypto/Cipher/DES3.py
+++ b/lib/Crypto/Cipher/DES3.py
@@ -116,7 +116,7 @@ def new(key, mode, *args, **kwargs):
 
     :param key:
         The secret key to use in the symmetric cipher.
-        It must be 8 byte long. The parity bits will be ignored.
+        It must be 16 or 24 byte long. The parity bits will be ignored.
     :type key: bytes/bytearray/memoryview
 
     :param mode:


### PR DESCRIPTION
🗝️ length must be 16 or 24 bytes long, not 8