### PR TITLE
Fix stacktrace when gmp.dll is present on Windows

### DIFF
--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -99,7 +99,7 @@ try:
         """
 
         lib = ffi.dlopen(name)
-        ffi.cdef(cdecl)
+        ffi.cdef(cdecl, override=True)
         return lib
 
     def c_ulong(x):


### PR DESCRIPTION
Fixes: https://github.com/Legrandin/pycryptodome/issues/427

I'm not sure if this is the correct fix as I don't know what `gmp.dll` is or does or how `cdef()` works or is supposed to work. I could find no documentation for the `override` parameter. Though this fixes the issue on Windows.