### PR TITLE
Use the builtin bit_length() that is available since 2.7

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,10 +53,7 @@ def size (N):
     if N < 0:
         raise ValueError("Size in bits only avialable for non-negative numbers")
 
-    bits = 0
-    while N >> bits:
-        bits += 1
-    return bits
+    return N.bit_length()
 
 
 def getRandomInteger(N, randfunc=None):


### PR DESCRIPTION
We can now safely use the superfast bit_length() to compute the size of a number now that Python<2.7 is no longer supported.