### PR TITLE
Improve speed of GCD, size, inverse

### DIFF
--- a/lib/Crypto/SelfTest/Util/test_number.py
+++ b/lib/Crypto/SelfTest/Util/test_number.py
@@ -129,7 +129,6 @@ class MiscTests(unittest.TestCase):
         self.assertEqual(number.size(0xa2),8)
         self.assertEqual(number.size(0xa2ba40),8*3)
         self.assertEqual(number.size(0xa2ba40ee07e3b2bd2f02ce227f36a195024486e49c19cb41bbbdfbba98b22b0e577c2eeaffa20d883a76e65e394c69d4b3c05a1e8fadda27edb2a42bc000fe888b9b32c22d15add0cd76b3e7936e19955b220dd17d4ea904b1ec102b2e4de7751222aa99151024c7cb41cc5ea21d00eeb41f7c800834d2c6e06bce3bce7ea9a5), 1024)
-        self.assertRaises(ValueError, number.size, -1)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Util/test_number.py
+++ b/lib/Crypto/SelfTest/Util/test_number.py
@@ -129,6 +129,7 @@ class MiscTests(unittest.TestCase):
         self.assertEqual(number.size(0xa2),8)
         self.assertEqual(number.size(0xa2ba40),8*3)
         self.assertEqual(number.size(0xa2ba40ee07e3b2bd2f02ce227f36a195024486e49c19cb41bbbdfbba98b22b0e577c2eeaffa20d883a76e65e394c69d4b3c05a1e8fadda27edb2a42bc000fe888b9b32c22d15add0cd76b3e7936e19955b220dd17d4ea904b1ec102b2e4de7751222aa99151024c7cb41cc5ea21d00eeb41f7c800834d2c6e06bce3bce7ea9a5), 1024)
+        self.assertEqual(number.size(-1), 1)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,7 +53,14 @@ def size (N):
     if N < 0:
         raise ValueError("Size in bits only avialable for non-negative numbers")
 
-    return N.bit_length()
+    try:
+        return N.bit_length()
+    except AttributeError:
+        # we have a very old python, use the slow way
+        bits = 0
+        while N >> bits:
+            bits += 1
+        return bits
 
 
 def getRandomInteger(N, randfunc=None):

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,10 +53,7 @@ def size (N):
     if N < 0:
         raise ValueError("Size in bits only avialable for non-negative numbers")
 
-    bits = 0
-    while N >> bits:
-        bits += 1
-    return bits
+    return N.bit_length()
 
 
 def getRandomInteger(N, randfunc=None):
@@ -117,6 +114,10 @@ def GCD(x,y):
     """Greatest Common Denominator of :data:`x` and :data:`y`.
     """
 
+    if hasattr(math, 'gcd'):
+        # the fast way
+	return math.gcd(x, y)
+
     x = abs(x) ; y = abs(y)
     while x > 0:
         x, y = y % x, x
@@ -124,6 +125,10 @@ def GCD(x,y):
 
 def inverse(u, v):
     """The inverse of :data:`u` *mod* :data:`v`."""
+
+    if sys.version_info[0:2] >= (3, 8):
+        # the fast way
+	return pow(u, -1, v)
 
     u3, v3 = u, v
     u1, v1 = 1, 0

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -57,6 +57,7 @@ else:
         This slow version for Python < 2.7
         """
 
+        N = abs(N)
         bits = 0
         while N >> bits:
             bits += 1

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -116,7 +116,7 @@ def GCD(x,y):
 
     if hasattr(math, 'gcd'):
         # the fast way
-	return math.gcd(x, y)
+        return math.gcd(x, y)
 
     x = abs(x) ; y = abs(y)
     while x > 0:
@@ -128,7 +128,7 @@ def inverse(u, v):
 
     if sys.version_info[0:2] >= (3, 8):
         # the fast way
-	return pow(u, -1, v)
+        return pow(u, -1, v)
 
     u3, v3 = u, v
     u1, v1 = 1, 0


### PR DESCRIPTION
Apply the following optimisations that use builtin C code where available:
Since Python 2.7 (i.e. always), the length of an integer can be computed with .bit_length()
Since Python 3.8, the inverse of a mod b can be computed with pow(a, -1, b)
Since Python 3.5, there is a gcd operation in the math module