### PR TITLE
Workaround parallel build failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -359,8 +359,7 @@ ext_modules = [
         py_limited_api=True),
     Extension("Crypto.Cipher._raw_eksblowfish",
         include_dirs=['src/'],
-        define_macros=[('EKS',None),],
-        sources=["src/blowfish.c"],
+        sources=["src/blowfish_eks.c"],
         py_limited_api=True),
     Extension("Crypto.Cipher._raw_cast",
         include_dirs=['src/'],
@@ -442,7 +441,8 @@ ext_modules = [
     # Math
     Extension("Crypto.Math._modexp",
         include_dirs=['src/'],
-        sources=['src/modexp.c', 'src/siphash.c', 'src/modexp_utils.c', 'src/mont.c'],
+        sources=['src/modexp.c', 'src/siphash_math.c',
+                 'src/modexp_utils_math.c', 'src/mont_math.c'],
         py_limited_api=True,
         ),
 ]

--- a/src/blowfish_eks.c
+++ b/src/blowfish_eks.c
@@ -1,0 +1,7 @@
+/*
+   This file is used to workaround a bug in distutils that causes race
+   conditions when the same source file is used in multiple extensions.
+ */
+
+#define EKS
+#include "blowfish.c"

--- a/src/modexp_utils_math.c
+++ b/src/modexp_utils_math.c
@@ -1,0 +1,6 @@
+/*
+   This file is used to workaround a bug in distutils that causes race
+   conditions when the same source file is used in multiple extensions.
+ */
+
+#include "modexp_utils.c"

--- a/src/mont_math.c
+++ b/src/mont_math.c
@@ -1,0 +1,6 @@
+/*
+   This file is used to workaround a bug in distutils that causes race
+   conditions when the same source file is used in multiple extensions.
+ */
+
+#include "mont.c"

--- a/src/siphash_math.c
+++ b/src/siphash_math.c
@@ -1,0 +1,6 @@
+/*
+   This file is used to workaround a bug in distutils that causes race
+   conditions when the same source file is used in multiple extensions.
+ */
+
+#include "siphash.c"


### PR DESCRIPTION
Use unique source file names to fix a race condition due to a distutils
bug.  The distutils build system does not handle the same source files
being used by multiple extensions correctly.  If parallel (-j) builds
are being done, the same file is compiled twice to the same output file.
This creates a race condition: if the second compilation starts while
the first extension is being linked, it is possible for the linker to
grab the incomplete file that is being written by the second compiler
call.

The simplest workaround for this is to create additional files that
include the original sources while providing a unique name for them.

Fixes #378