### PR TITLE
Crypto.Util.asn1: add DerBoolean

### DIFF
--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -382,7 +382,7 @@ class DerBoolean(DerObject):
 
                 DerObject.__init__(self, 0x01, b'', implicit,
                                    False, explicit)
-                self.value = bool(value)  # The boolean value
+                self.value = value  # The boolean value
 
         def encode(self):
                 """Return the DER BOOLEAN, fully encoded as a

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -827,7 +827,7 @@ class DerBitString(DerObject):
             If not specified, the bit string is empty.
           implicit : integer
             The IMPLICIT tag to use for the encoded object.
-            It overrides the universal tag for OCTET STRING (3).
+            It overrides the universal tag for BIT STRING (3).
           explicit : integer
             The EXPLICIT tag to use for the encoded object.
         """


### PR DESCRIPTION
Templated off the existing DerInteger class; I believe it should be all correct.

```python-repl
>>> from Crypto.Util.asn1 import DerBoolean
>>> from binascii import hexlify, unhexlify
>>> hexlify(DerBoolean(True).encode())
b'0101ff'
>>> hexlify(DerBoolean(False).encode())
b'010100'
>>> DerBoolean().decode(unhexlify(b'0101ff')).value
True
>>> DerBoolean().decode(unhexlify(b'010101')).value
True
>>> DerBoolean().decode(unhexlify(b'0101ff'), strict=True).value
True
>>> DerBoolean().decode(unhexlify(b'010100'), strict=True).value
False
>>> DerBoolean().decode(unhexlify(b'010101'), strict=True).value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 405, in decode
    return DerObject.decode(self, der_encoded, strict=strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 214, in decode
    self._decodeFromStream(s, strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 430, in _decodeFromStream
    raise ValueError("Invalid encoding for DER BOOLEAN: content must either be single-octet zero or single-octet all-ones")
ValueError: Invalid encoding for DER BOOLEAN: content must either be single-octet zero or single-octet all-ones
>>> DerBoolean().decode(b'\x01\x02\x00\x00', strict=True).value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 405, in decode
    return DerObject.decode(self, der_encoded, strict=strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 214, in decode
    self._decodeFromStream(s, strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 417, in _decodeFromStream
    raise ValueError("Invalid encoding for DER BOOLEAN: leading zero")
ValueError: Invalid encoding for DER BOOLEAN: leading zero
>>> DerBoolean().decode(unhexlify(b'0100')).value
False
>>> DerBoolean().decode(unhexlify(b'0100'), strict=True).value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 405, in decode
    return DerObject.decode(self, der_encoded, strict=strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 214, in decode
    self._decodeFromStream(s, strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 415, in _decodeFromStream
    raise ValueError("Invalid encoding for DER BOOLEAN: empty payload")
ValueError: Invalid encoding for DER BOOLEAN: empty payload
>>> DerBoolean().decode(unhexlify(b'01020000')).value
False
>>> DerBoolean().decode(unhexlify(b'01020000'), strict=True).value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 405, in decode
    return DerObject.decode(self, der_encoded, strict=strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 214, in decode
    self._decodeFromStream(s, strict)
  File "/home/�/.local/lib/python3.8/site-packages/Crypto/Util/asn1.py", line 417, in _decodeFromStream
    raise ValueError("Invalid encoding for DER BOOLEAN: leading zero")
ValueError: Invalid encoding for DER BOOLEAN: leading zero
>>> 
```