### PR TITLE
Add more precise type annotations for Python 3.8+

### DIFF
--- a/lib/Crypto/Cipher/AES.pyi
+++ b/lib/Crypto/Cipher/AES.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Union, Tuple, Optional, Dict, overload
+from typing import ByteString, Dict, Optional, Tuple, Union, overload
 
 from Crypto.Cipher._mode_ecb import EcbMode
 from Crypto.Cipher._mode_cbc import CbcMode
@@ -224,6 +224,6 @@ else:
                   OpenPgpMode, CcmMode, EaxMode, GcmMode,
                   SivMode, OcbMode]: ...
 
-Buffer = Union[bytes, bytearray, memoryview]
+Buffer = ByteString
 block_size: int
 key_size: Tuple[int, int, int]

--- a/lib/Crypto/Cipher/AES.pyi
+++ b/lib/Crypto/Cipher/AES.pyi
@@ -43,14 +43,6 @@ if sys.version_info >= (3, 8):
     @overload
     def new(key: Buffer,
             mode: MODE_ECB,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
-            nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             EcbMode: ...
 
@@ -59,12 +51,6 @@ if sys.version_info >= (3, 8):
             mode: MODE_CBC,
             iv : Buffer = ...,
             IV : Buffer = ...,
-            nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             CbcMode: ...
 
@@ -75,10 +61,6 @@ if sys.version_info >= (3, 8):
             IV : Buffer = ...,
             nonce : Buffer = ...,
             segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             CfbMode: ...
 
@@ -87,24 +69,13 @@ if sys.version_info >= (3, 8):
             mode: MODE_OFB,
             iv : Buffer = ...,
             IV : Buffer = ...,
-            nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             OfbMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_CTR,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
             initial_value : Union[int, Buffer] = ...,
             counter : Dict = ...,
             use_aesni : bool = ...) -> \
@@ -115,82 +86,46 @@ if sys.version_info >= (3, 8):
             mode: MODE_OPENPGP,
             iv : Buffer = ...,
             IV : Buffer = ...,
-            nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             OpenPgpMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_CCM,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
             mac_len : int = ...,
             assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             CcmMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_EAX,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
             mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             EaxMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_SIV,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
-            mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             SivMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_GCM,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
             mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             GcmMode: ...
 
     @overload
     def new(key: Buffer,
             mode: MODE_OCB,
-            iv : Buffer = ...,
-            IV : Buffer = ...,
             nonce : Buffer = ...,
-            segment_size : int = ...,
             mac_len : int = ...,
-            assoc_len : int = ...,
-            initial_value : Union[int, Buffer] = ...,
-            counter : Dict = ...,
             use_aesni : bool = ...) -> \
             OcbMode: ...
 

--- a/lib/Crypto/Cipher/AES.pyi
+++ b/lib/Crypto/Cipher/AES.pyi
@@ -59,7 +59,6 @@ if sys.version_info >= (3, 8):
             mode: MODE_CFB,
             iv : Buffer = ...,
             IV : Buffer = ...,
-            nonce : Buffer = ...,
             segment_size : int = ...,
             use_aesni : bool = ...) -> \
             CfbMode: ...

--- a/lib/Crypto/Cipher/AES.pyi
+++ b/lib/Crypto/Cipher/AES.pyi
@@ -1,4 +1,5 @@
-from typing import Union, Tuple, Optional, Dict
+import sys
+from typing import Union, Tuple, Optional, Dict, overload
 
 from Crypto.Cipher._mode_ecb import EcbMode
 from Crypto.Cipher._mode_cbc import CbcMode
@@ -12,36 +13,217 @@ from Crypto.Cipher._mode_gcm import GcmMode
 from Crypto.Cipher._mode_siv import SivMode
 from Crypto.Cipher._mode_ocb import OcbMode
 
-AESMode = int
+if sys.version_info >= (3, 8):
+    MODE_ECB: Literal[1]
+    MODE_CBC: Literal[2]
+    MODE_CFB: Literal[3]
+    MODE_OFB: Literal[5]
+    MODE_CTR: Literal[6]
+    MODE_OPENPGP: Literal[7]
+    MODE_CCM: Literal[8]
+    MODE_EAX: Literal[9]
+    MODE_SIV: Literal[10]
+    MODE_GCM: Literal[11]
+    MODE_OCB: Literal[12]
 
-MODE_ECB: AESMode
-MODE_CBC: AESMode
-MODE_CFB: AESMode
-MODE_OFB: AESMode
-MODE_CTR: AESMode
-MODE_OPENPGP: AESMode
-MODE_CCM: AESMode
-MODE_EAX: AESMode
-MODE_GCM: AESMode
-MODE_SIV: AESMode
-MODE_OCB: AESMode
+    AESMode = Union[
+        MODE_ECB,
+        MODE_CBC,
+        MODE_CFB,
+        MODE_OFB,
+        MODE_CTR,
+        MODE_OPENPGP,
+        MODE_CCM,
+        MODE_EAX,
+        MODE_GCM,
+        MODE_SIV,
+        MODE_OCB,
+    ]
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_ECB,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            EcbMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_CBC,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            CbcMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_CFB,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            CfbMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_OFB,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            OfbMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_CTR,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            CtrMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_OPENPGP,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            OpenPgpMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_CCM,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            CcmMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_EAX,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            EaxMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_SIV,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            SivMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_GCM,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            GcmMode: ...
+
+    @overload
+    def new(key: Buffer,
+            mode: MODE_OCB,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            OcbMode: ...
+
+else:   
+    AESMode = int
+
+    MODE_ECB: AESMode
+    MODE_CBC: AESMode
+    MODE_CFB: AESMode
+    MODE_OFB: AESMode
+    MODE_CTR: AESMode
+    MODE_OPENPGP: AESMode
+    MODE_CCM: AESMode
+    MODE_EAX: AESMode
+    MODE_GCM: AESMode
+    MODE_SIV: AESMode
+    MODE_OCB: AESMode
+
+    def new(key: Buffer,
+            mode: AESMode,
+            iv : Buffer = ...,
+            IV : Buffer = ...,
+            nonce : Buffer = ...,
+            segment_size : int = ...,
+            mac_len : int = ...,
+            assoc_len : int = ...,
+            initial_value : Union[int, Buffer] = ...,
+            counter : Dict = ...,
+            use_aesni : bool = ...) -> \
+            Union[EcbMode, CbcMode, CfbMode, OfbMode, CtrMode,
+                  OpenPgpMode, CcmMode, EaxMode, GcmMode,
+                  SivMode, OcbMode]: ...
 
 Buffer = Union[bytes, bytearray, memoryview]
-
-def new(key: Buffer,
-        mode: AESMode,
-        iv : Buffer = ...,
-        IV : Buffer = ...,
-        nonce : Buffer = ...,
-        segment_size : int = ...,
-        mac_len : int = ...,
-        assoc_len : int = ...,
-        initial_value : Union[int, Buffer] = ...,
-        counter : Dict = ...,
-        use_aesni : bool = ...) -> \
-        Union[EcbMode, CbcMode, CfbMode, OfbMode, CtrMode,
-              OpenPgpMode, CcmMode, EaxMode, GcmMode,
-              SivMode, OcbMode]: ...
-
 block_size: int
 key_size: Tuple[int, int, int]


### PR DESCRIPTION
Hello,

`AES.new` returns a `Union` type, which means that a type checker like Mypy cannot know which type exactly is returned. This is a problem if you want to use an attribute that is present on some members of the union but not other members.

For example, `CbcMode` has an `iv` attribute, but `EcbMode` does not. Therefore this code will not type check:

```python
cipher = AES.new(aes_key, AES.MODE_CBC)
print(cipher.iv)
```

On Python 3.8 and above, we can solve this problem with `typing.Literal` and `typing.overload`.

I also replaced `Union[bytes, bytearray, memoryview]` with [`ByteString`](https://docs.python.org/3/library/typing.html#typing.ByteString), but if there is a specific reason to use the former I can change it back.

Apologies if I have not followed proper contribution procedures. I didn't see a contributor guide in the repository.

Edit: I see similar issues with several of the other `Crypto.Cipher` type stubs, e.g. https://github.com/gwerbin/pycryptodome/blob/master/lib/Crypto/Cipher/DES.pyi. I am happy to extend this PR to include the others if the maintainers want to proceed.