### PR TITLE
Fix segemation errror for ARM64/ Apple siliion 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,3 +47,4 @@ Barry A. Warsaw
 Eric Young
 Hannes van Niekerk
 Stefan Seering
+Ghassan Maslamani

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+3.10.3 (22 September 2021)
+++++++++++++++++++++++++++
+
+Resolved issues 
+---------------
+* GH#506 Solve segmentation error which might occur on apple silicon when using GMP, 
+  the work around was to raise a new exception in Numbers module, if ARM64 is detected as the platform,
+  so that Numbers would export IntegerCustom or IntegerNative instead of IntegerGMP. 
+* GH#509 This might be fixed as well, as it's related to GH#506   
+
+
 3.10.2 (22 September 2021)
 ++++++++++++++++++++++++++
 

--- a/lib/Crypto/Math/Numbers.py
+++ b/lib/Crypto/Math/Numbers.py
@@ -28,10 +28,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ===================================================================
 import platform
+import sys
 __all__ = ["Integer"]
 
 try:
-    if platform.machine() == 'arm64':
+    if platform.machine() == 'arm64' and  sys.platform == 'darwin':
         #Check release notes https://gmplib.org/gmp6.2 
         raise OSError('Platform not yet fully compatible with GMP')
     from Crypto.Math._IntegerGMP import IntegerGMP as Integer

--- a/lib/Crypto/Math/Numbers.py
+++ b/lib/Crypto/Math/Numbers.py
@@ -27,10 +27,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # ===================================================================
-
+import platform
 __all__ = ["Integer"]
 
 try:
+    if platform.machine() == 'arm64':
+        #Check release notes https://gmplib.org/gmp6.2 
+        raise OSError('Platform not yet fully compatible with GMP')
     from Crypto.Math._IntegerGMP import IntegerGMP as Integer
     from Crypto.Math._IntegerGMP import implementation as _implementation
 except (ImportError, OSError, AttributeError):

--- a/lib/Crypto/SelfTest/Math/test_Numbers.py
+++ b/lib/Crypto/SelfTest/Math/test_Numbers.py
@@ -750,7 +750,7 @@ def get_tests(config={}):
     tests += list_test_cases(TestIntegerInt)
 
     try:
-        if platform.machine() == 'arm64':
+        if platform.machine() == 'arm64' and sys.platform == 'darwin':
         #Check release notes https://gmplib.org/gmp6.2
             raise OSError('Platform not yet fully compatible with GMP')    
         from Crypto.Math._IntegerGMP import IntegerGMP
@@ -763,7 +763,7 @@ def get_tests(config={}):
     except (ImportError, OSError) as e:
         if sys.platform == "win32":
             sys.stdout.write("Skipping GMP tests on Windows\n")
-        elif platform.machine() == 'arm64':
+        elif platform.machine() == 'arm64' and sys.platform == 'darwin':
                 sys.stdout.write("Skipping GMP tests on Apple silicon\n")
         else:
             sys.stdout.write("Skipping GMP tests (%s)\n" % str(e) )

--- a/lib/Crypto/SelfTest/Math/test_Numbers.py
+++ b/lib/Crypto/SelfTest/Math/test_Numbers.py
@@ -35,7 +35,7 @@
 
 import sys
 import unittest
-
+import platform
 from Crypto.SelfTest.st_common import list_test_cases
 
 from Crypto.Util.py3compat import *
@@ -750,6 +750,9 @@ def get_tests(config={}):
     tests += list_test_cases(TestIntegerInt)
 
     try:
+        if platform.machine() == 'arm64':
+        #Check release notes https://gmplib.org/gmp6.2
+            raise OSError('Platform not yet fully compatible with GMP')    
         from Crypto.Math._IntegerGMP import IntegerGMP
 
         class TestIntegerGMP(TestIntegerBase):
@@ -760,6 +763,8 @@ def get_tests(config={}):
     except (ImportError, OSError) as e:
         if sys.platform == "win32":
             sys.stdout.write("Skipping GMP tests on Windows\n")
+        elif platform.machine() == 'arm64':
+                sys.stdout.write("Skipping GMP tests on Apple silicon\n")
         else:
             sys.stdout.write("Skipping GMP tests (%s)\n" % str(e) )
 


### PR DESCRIPTION
Relevant issues are
-  #509
-  #506 

Description of work:

Solve segmentation error which might occur on apple silicon when using GMP, 
the work around was to raise a new exception in Numbers module, if ARM64 is detected as the platform,
so that Numbers would export IntegerCustom or IntegerNative instead of IntegerGMP. 