### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/lib/Crypto/SelfTest/Cipher/test_ARC4.py
+++ b/lib/Crypto/SelfTest/Cipher/test_ARC4.py
@@ -419,7 +419,7 @@ class RFC6229_Tests(unittest.TestCase):
                 expected = tv[1].get(offset)
                 if expected:
                     expected = unhexlify(b(expected.replace(" ",'')))
-                    self.assertEquals(ct, expected)
+                    self.assertEqual(ct, expected)
                     count += 1
             self.assertEqual(count, len(tv[1]))
 
@@ -434,13 +434,13 @@ class Drop_Tests(unittest.TestCase):
         cipher_drop = ARC4.new(self.key, 256)
         ct_drop = cipher_drop.encrypt(self.data[:16])
         ct = self.cipher.encrypt(self.data)[256:256+16]
-        self.assertEquals(ct_drop, ct)
+        self.assertEqual(ct_drop, ct)
 
     def test_drop256_decrypt(self):
         cipher_drop = ARC4.new(self.key, 256)
         pt_drop = cipher_drop.decrypt(self.data[:16])
         pt = self.cipher.decrypt(self.data)[256:256+16]
-        self.assertEquals(pt_drop, pt)
+        self.assertEqual(pt_drop, pt)
 
 
 class KeyLength(unittest.TestCase):

--- a/lib/Crypto/SelfTest/Cipher/test_CBC.py
+++ b/lib/Crypto/SelfTest/Cipher/test_CBC.py
@@ -81,10 +81,10 @@ class BlockChainingTests(unittest.TestCase):
         ct = cipher.encrypt(self.data_128)
 
         cipher = AES.new(self.key_128, self.aes_mode, iv=self.iv_128)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
         cipher = AES.new(self.key_128, self.aes_mode, IV=self.iv_128)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_iv_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_128, self.aes_mode,

--- a/lib/Crypto/SelfTest/Cipher/test_CCM.py
+++ b/lib/Crypto/SelfTest/Cipher/test_CCM.py
@@ -72,7 +72,7 @@ class CcmTests(unittest.TestCase):
         ct = cipher.encrypt(self.data_128)
 
         cipher = AES.new(self.key_128, AES.MODE_CCM, nonce=self.nonce_96)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_128, AES.MODE_CCM,
@@ -276,7 +276,7 @@ class CcmTests(unittest.TestCase):
             for chunk in break_up(plaintext, chunk_length):
                 ct2 += cipher.encrypt(chunk)
             self.assertEqual(ciphertext, ct2)
-            self.assertEquals(cipher.digest(), ref_mac)
+            self.assertEqual(cipher.digest(), ref_mac)
 
     def test_bytearray(self):
 

--- a/lib/Crypto/SelfTest/Cipher/test_CTR.py
+++ b/lib/Crypto/SelfTest/Cipher/test_CTR.py
@@ -86,7 +86,7 @@ class CtrTests(unittest.TestCase):
         # Nonce attribute is not defined if suffix is used in Counter
         counter = Counter.new(64, prefix=self.nonce_32, suffix=self.nonce_32)
         cipher = AES.new(self.key_128, AES.MODE_CTR, counter=counter)
-        self.failIf(hasattr(cipher, "nonce"))
+        self.assertFalse(hasattr(cipher, "nonce"))
 
     def test_nonce_parameter(self):
         # Nonce parameter becomes nonce attribute

--- a/lib/Crypto/SelfTest/Cipher/test_ChaCha20.py
+++ b/lib/Crypto/SelfTest/Cipher/test_ChaCha20.py
@@ -58,7 +58,7 @@ class ChaCha20Test(unittest.TestCase):
     def test_default_nonce(self):
         cipher1 = ChaCha20.new(key=bchr(1) * 32)
         cipher2 = ChaCha20.new(key=bchr(1) * 32)
-        self.assertEquals(len(cipher1.nonce), 8)
+        self.assertEqual(len(cipher1.nonce), 8)
         self.assertNotEqual(cipher1.nonce, cipher2.nonce)
 
     def test_nonce(self):
@@ -128,7 +128,7 @@ class ChaCha20Test(unittest.TestCase):
         cipher2.seek(offset)
         ct2 = cipher2.encrypt(pt)
 
-        self.assertEquals(ct1, ct2)
+        self.assertEqual(ct1, ct2)
 
     def test_seek_tv(self):
         # Test Vector #4, A.1 from

--- a/lib/Crypto/SelfTest/Cipher/test_ChaCha20_Poly1305.py
+++ b/lib/Crypto/SelfTest/Cipher/test_ChaCha20_Poly1305.py
@@ -85,7 +85,7 @@ class ChaCha20Poly1305Tests(unittest.TestCase):
 
         cipher = ChaCha20_Poly1305.new(key=self.key_256,
                                        nonce=self.nonce_96)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError,
@@ -108,7 +108,7 @@ class ChaCha20Poly1305Tests(unittest.TestCase):
         # Not based on block ciphers
         cipher = ChaCha20_Poly1305.new(key=self.key_256,
                                        nonce=self.nonce_96)
-        self.failIf(hasattr(cipher, 'block_size'))
+        self.assertFalse(hasattr(cipher, 'block_size'))
 
     def test_nonce_attribute(self):
         cipher = ChaCha20_Poly1305.new(key=self.key_256,
@@ -225,7 +225,7 @@ class ChaCha20Poly1305Tests(unittest.TestCase):
             for chunk in break_up(plaintext, chunk_length):
                 ct2 += cipher.encrypt(chunk)
             self.assertEqual(ciphertext, ct2)
-            self.assertEquals(cipher.digest(), ref_mac)
+            self.assertEqual(cipher.digest(), ref_mac)
 
     def test_bytearray(self):
 

--- a/lib/Crypto/SelfTest/Cipher/test_EAX.py
+++ b/lib/Crypto/SelfTest/Cipher/test_EAX.py
@@ -82,7 +82,7 @@ class EaxTests(unittest.TestCase):
         ct = cipher.encrypt(self.data_128)
 
         cipher = AES.new(self.key_128, AES.MODE_EAX, nonce=self.nonce_96)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_128, AES.MODE_EAX,
@@ -225,7 +225,7 @@ class EaxTests(unittest.TestCase):
             for chunk in break_up(plaintext, chunk_length):
                 ct2 += cipher.encrypt(chunk)
             self.assertEqual(ciphertext, ct2)
-            self.assertEquals(cipher.digest(), ref_mac)
+            self.assertEqual(cipher.digest(), ref_mac)
 
     def test_bytearray(self):
 

--- a/lib/Crypto/SelfTest/Cipher/test_GCM.py
+++ b/lib/Crypto/SelfTest/Cipher/test_GCM.py
@@ -70,7 +70,7 @@ class GcmTests(unittest.TestCase):
         ct = cipher.encrypt(self.data_128)
 
         cipher = AES.new(self.key_128, AES.MODE_GCM, nonce=self.nonce_96)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_128, AES.MODE_GCM,
@@ -209,7 +209,7 @@ class GcmTests(unittest.TestCase):
             for chunk in break_up(plaintext, chunk_length):
                 ct2 += cipher.encrypt(chunk)
             self.assertEqual(ciphertext, ct2)
-            self.assertEquals(cipher.digest(), ref_mac)
+            self.assertEqual(cipher.digest(), ref_mac)
 
     def test_bytearray(self):
 

--- a/lib/Crypto/SelfTest/Cipher/test_OCB.py
+++ b/lib/Crypto/SelfTest/Cipher/test_OCB.py
@@ -69,7 +69,7 @@ class OcbTests(unittest.TestCase):
         ct = cipher.encrypt(self.data_128)
 
         cipher = AES.new(self.key_128, AES.MODE_OCB, nonce=self.nonce_96)
-        self.assertEquals(ct, cipher.encrypt(self.data_128))
+        self.assertEqual(ct, cipher.encrypt(self.data_128))
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_128, AES.MODE_OCB,
@@ -219,7 +219,7 @@ class OcbTests(unittest.TestCase):
                 ct2 += cipher.encrypt(chunk)
             ct2 += cipher.encrypt()
             self.assertEqual(ciphertext, ct2)
-            self.assertEquals(cipher.digest(), ref_mac)
+            self.assertEqual(cipher.digest(), ref_mac)
 
     def test_bytearray(self):
 
@@ -671,13 +671,13 @@ class OcbRfc7253Test(unittest.TestCase):
             cipher = AES.new(key, AES.MODE_OCB, nonce=nonce)
             cipher.update(aad)
             ct2 = cipher.encrypt(pt) + cipher.encrypt()
-            self.assertEquals(ct, ct2)
-            self.assertEquals(mac_tag, cipher.digest())
+            self.assertEqual(ct, ct2)
+            self.assertEqual(mac_tag, cipher.digest())
 
             cipher = AES.new(key, AES.MODE_OCB, nonce=nonce)
             cipher.update(aad)
             pt2 = cipher.decrypt(ct) + cipher.decrypt()
-            self.assertEquals(pt, pt2)
+            self.assertEqual(pt, pt2)
             cipher.verify(mac_tag)
 
     def test2(self):
@@ -688,13 +688,13 @@ class OcbRfc7253Test(unittest.TestCase):
         cipher = AES.new(key, AES.MODE_OCB, nonce=nonce, mac_len=12)
         cipher.update(aad)
         ct2 = cipher.encrypt(pt) + cipher.encrypt()
-        self.assertEquals(ct, ct2)
-        self.assertEquals(mac_tag, cipher.digest())
+        self.assertEqual(ct, ct2)
+        self.assertEqual(mac_tag, cipher.digest())
 
         cipher = AES.new(key, AES.MODE_OCB, nonce=nonce, mac_len=12)
         cipher.update(aad)
         pt2 = cipher.decrypt(ct) + cipher.decrypt()
-        self.assertEquals(pt, pt2)
+        self.assertEqual(pt, pt2)
         cipher.verify(mac_tag)
 
     def test3(self):
@@ -725,7 +725,7 @@ class OcbRfc7253Test(unittest.TestCase):
             cipher = AES.new(key, AES.MODE_OCB, nonce=N, mac_len=taglen // 8)
             cipher.update(C)
             result2 = cipher.encrypt() + cipher.digest()
-            self.assertEquals(unhexlify(b(result)), result2)
+            self.assertEqual(unhexlify(b(result)), result2)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Cipher/test_SIV.py
+++ b/lib/Crypto/SelfTest/Cipher/test_SIV.py
@@ -73,7 +73,7 @@ class SivTests(unittest.TestCase):
 
         cipher = AES.new(self.key_256, AES.MODE_SIV, nonce=self.nonce_96)
         ct2, tag2 = cipher.encrypt_and_digest(self.data_128)
-        self.assertEquals(ct1 + tag1, ct2 + tag2)
+        self.assertEqual(ct1 + tag1, ct2 + tag2)
 
     def test_nonce_must_be_bytes(self):
         self.assertRaises(TypeError, AES.new, self.key_256, AES.MODE_SIV,
@@ -97,7 +97,7 @@ class SivTests(unittest.TestCase):
         self.assertEqual(cipher.nonce, self.nonce_96)
 
         # By default, no nonce is randomly generated
-        self.failIf(hasattr(AES.new(self.key_256, AES.MODE_SIV), "nonce"))
+        self.assertFalse(hasattr(AES.new(self.key_256, AES.MODE_SIV), "nonce"))
 
     def test_unknown_parameters(self):
         self.assertRaises(TypeError, AES.new, self.key_256, AES.MODE_SIV,

--- a/lib/Crypto/SelfTest/Hash/common.py
+++ b/lib/Crypto/SelfTest/Hash/common.py
@@ -52,11 +52,11 @@ class HashDigestSizeSelfTest(unittest.TestCase):
 
     def runTest(self):
         if "truncate" not in self.extra_params:
-            self.failUnless(hasattr(self.hashmod, "digest_size"))
-            self.assertEquals(self.hashmod.digest_size, self.expected)
+            self.assertTrue(hasattr(self.hashmod, "digest_size"))
+            self.assertEqual(self.hashmod.digest_size, self.expected)
         h = self.hashmod.new(**self.extra_params)
-        self.failUnless(hasattr(h, "digest_size"))
-        self.assertEquals(h.digest_size, self.expected)
+        self.assertTrue(hasattr(h, "digest_size"))
+        self.assertEqual(h.digest_size, self.expected)
 
 
 class HashSelfTest(unittest.TestCase):

--- a/lib/Crypto/SelfTest/Hash/test_BLAKE2.py
+++ b/lib/Crypto/SelfTest/Hash/test_BLAKE2.py
@@ -88,7 +88,7 @@ class Blake2Test(unittest.TestCase):
 
     def test_default_digest_size(self):
         digest = self.BLAKE2.new(data=b'abc').digest()
-        self.assertEquals(len(digest), self.max_bytes)
+        self.assertEqual(len(digest), self.max_bytes)
 
     def test_update(self):
         pieces = [b"\x0A" * 200, b"\x14" * 300]
@@ -110,7 +110,7 @@ class Blake2Test(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(h.digest(), digest)
         # digest returns a byte string
-        self.failUnless(isinstance(digest, type(b"digest")))
+        self.assertTrue(isinstance(digest, type(b"digest")))
 
     def test_update_after_digest(self):
         msg = b"rrrrttt"
@@ -123,11 +123,11 @@ class Blake2Test(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = self.BLAKE2.new(digest_bits=256, data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
     def test_hex_digest(self):
         mac = self.BLAKE2.new(digest_bits=self.max_bits)
@@ -139,7 +139,7 @@ class Blake2Test(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(mac.hexdigest(), hexdigest)
         # hexdigest returns a string
-        self.failUnless(isinstance(hexdigest, type("digest")))
+        self.assertTrue(isinstance(hexdigest, type("digest")))
 
     def test_verify(self):
         h = self.BLAKE2.new(digest_bytes=self.max_bytes, key=b"4")

--- a/lib/Crypto/SelfTest/Hash/test_CMAC.py
+++ b/lib/Crypto/SelfTest/Hash/test_CMAC.py
@@ -284,11 +284,11 @@ class TestCMAC(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h2 = CMAC.new(key, msg[:4], ciphermod=AES, update_after_digest=True)
-        self.assertEquals(h2.digest(), dig1)
+        self.assertEqual(h2.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h2.update(msg[4:])
-        self.assertEquals(h2.digest(), dig2)
+        self.assertEqual(h2.digest(), dig2)
 
 
 class ByteArrayTests(unittest.TestCase):

--- a/lib/Crypto/SelfTest/Hash/test_Poly1305.py
+++ b/lib/Crypto/SelfTest/Hash/test_Poly1305.py
@@ -358,7 +358,7 @@ class Poly1305Test_AES(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(h.digest(), digest)
         # digest returns a byte string
-        self.failUnless(isinstance(digest, type(b"digest")))
+        self.assertTrue(isinstance(digest, type(b"digest")))
 
     def test_update_after_digest(self):
         msg=b"rrrrttt"
@@ -378,7 +378,7 @@ class Poly1305Test_AES(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(mac.hexdigest(), hexdigest)
         # hexdigest returns a string
-        self.failUnless(isinstance(hexdigest, type("digest")))
+        self.assertTrue(isinstance(hexdigest, type("digest")))
 
     def test_verify(self):
         h = Poly1305.new(key=self.key, cipher=AES)

--- a/lib/Crypto/SelfTest/Hash/test_SHA3_224.py
+++ b/lib/Crypto/SelfTest/Hash/test_SHA3_224.py
@@ -44,11 +44,11 @@ class APITest(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = SHA3.new(data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Hash/test_SHA3_256.py
+++ b/lib/Crypto/SelfTest/Hash/test_SHA3_256.py
@@ -44,11 +44,11 @@ class APITest(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = SHA3.new(data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Hash/test_SHA3_384.py
+++ b/lib/Crypto/SelfTest/Hash/test_SHA3_384.py
@@ -44,11 +44,11 @@ class APITest(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = SHA3.new(data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Hash/test_SHA3_512.py
+++ b/lib/Crypto/SelfTest/Hash/test_SHA3_512.py
@@ -44,11 +44,11 @@ class APITest(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = SHA3.new(data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
 
 def get_tests(config={}):

--- a/lib/Crypto/SelfTest/Hash/test_SHAKE.py
+++ b/lib/Crypto/SelfTest/Hash/test_SHAKE.py
@@ -69,7 +69,7 @@ class SHAKETest(unittest.TestCase):
         digest = h.read(90)
 
         # read returns a byte string of the right length
-        self.failUnless(isinstance(digest, type(b("digest"))))
+        self.assertTrue(isinstance(digest, type(b("digest"))))
         self.assertEqual(len(digest), 90)
 
     def test_update_after_read(self):

--- a/lib/Crypto/SelfTest/Hash/test_cSHAKE.py
+++ b/lib/Crypto/SelfTest/Hash/test_cSHAKE.py
@@ -98,7 +98,7 @@ class cSHAKETest(unittest.TestCase):
         digest = h.read(90)
 
         # read returns a byte string of the right length
-        self.failUnless(isinstance(digest, type(b("digest"))))
+        self.assertTrue(isinstance(digest, type(b("digest"))))
         self.assertEqual(len(digest), 90)
 
     def test_update_after_read(self):

--- a/lib/Crypto/SelfTest/Hash/test_keccak.py
+++ b/lib/Crypto/SelfTest/Hash/test_keccak.py
@@ -103,7 +103,7 @@ class KeccakTest(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(h.digest(), digest)
         # digest returns a byte string
-        self.failUnless(isinstance(digest, type(b("digest"))))
+        self.assertTrue(isinstance(digest, type(b("digest"))))
 
     def test_hex_digest(self):
         mac = keccak.new(digest_bits=512)
@@ -115,7 +115,7 @@ class KeccakTest(unittest.TestCase):
         # hexdigest does not change the state
         self.assertEqual(mac.hexdigest(), hexdigest)
         # hexdigest returns a string
-        self.failUnless(isinstance(hexdigest, type("digest")))
+        self.assertTrue(isinstance(hexdigest, type("digest")))
 
     def test_update_after_digest(self):
         msg=b("rrrrttt")
@@ -128,11 +128,11 @@ class KeccakTest(unittest.TestCase):
 
         # With the proper flag, it is allowed
         h = keccak.new(digest_bits=512, data=msg[:4], update_after_digest=True)
-        self.assertEquals(h.digest(), dig1)
+        self.assertEqual(h.digest(), dig1)
         # ... and the subsequent digest applies to the entire message
         # up to that point
         h.update(msg[4:])
-        self.assertEquals(h.digest(), dig2)
+        self.assertEqual(h.digest(), dig2)
 
 
 class KeccakVectors(unittest.TestCase):

--- a/lib/Crypto/SelfTest/Protocol/test_SecretSharing.py
+++ b/lib/Crypto/SelfTest/Protocol/test_SecretSharing.py
@@ -73,7 +73,7 @@ class GF2_Tests(TestCase):
         from Crypto.Util.number import size as deg
 
         x, y = _div_gf2(567, 7)
-        self.failUnless(deg(y) < deg(7))
+        self.assertTrue(deg(y) < deg(7))
 
         w = _mult_gf2(x, 7) ^ y
         self.assertEqual(567, w)

--- a/lib/Crypto/SelfTest/PublicKey/test_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_DSA.py
@@ -156,7 +156,7 @@ class DSATest(unittest.TestCase):
 
         # Check __eq__ and __ne__
         self.assertEqual(dsaObj.public_key() == dsaObj.public_key(),True) # assert_
-        self.assertEqual(dsaObj.public_key() != dsaObj.public_key(),False) # failIf
+        self.assertEqual(dsaObj.public_key() != dsaObj.public_key(),False) # assertFalse
 
         self.assertEqual(dsaObj.public_key(), dsaObj.publickey()) 
 
@@ -172,8 +172,8 @@ class DSATest(unittest.TestCase):
         m_hash = bytes_to_long(a2b_hex(self.m_hash))
         r = bytes_to_long(a2b_hex(self.r))
         s = bytes_to_long(a2b_hex(self.s))
-        self.failUnless(dsaObj._verify(m_hash, (r, s)))
-        self.failIf(dsaObj._verify(m_hash + 1, (r, s)))
+        self.assertTrue(dsaObj._verify(m_hash, (r, s)))
+        self.assertFalse(dsaObj._verify(m_hash + 1, (r, s)))
 
     def test_repr(self):
         (y, g, p, q) = [bytes_to_long(a2b_hex(param)) for param in (self.y, self.g, self.p, self.q)]

--- a/lib/Crypto/SelfTest/PublicKey/test_ECC.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_ECC.py
@@ -541,14 +541,14 @@ class TestEccKey_P256(unittest.TestCase):
 
         key = EccKey(curve="P-256", d=1)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ.x, _curves['p256'].Gx)
         self.assertEqual(key.pointQ.y, _curves['p256'].Gy)
 
         point = EccPoint(_curves['p256'].Gx, _curves['p256'].Gy)
         key = EccKey(curve="P-256", d=1, point=point)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, point)
 
         # Other names
@@ -559,14 +559,14 @@ class TestEccKey_P256(unittest.TestCase):
 
         point = EccPoint(_curves['p256'].Gx, _curves['p256'].Gy)
         key = EccKey(curve="P-256", point=point)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, point)
 
     def test_public_key_derived(self):
 
         priv_key = EccKey(curve="P-256", d=3)
         pub_key = priv_key.public_key()
-        self.failIf(pub_key.has_private())
+        self.assertFalse(pub_key.has_private())
         self.assertEqual(priv_key.pointQ, pub_key.pointQ)
 
     def test_invalid_curve(self):
@@ -603,14 +603,14 @@ class TestEccKey_P384(unittest.TestCase):
 
         key = EccKey(curve="P-384", d=1)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ.x, p384.Gx)
         self.assertEqual(key.pointQ.y, p384.Gy)
 
         point = EccPoint(p384.Gx, p384.Gy, "p384")
         key = EccKey(curve="P-384", d=1, point=point)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, point)
 
         # Other names
@@ -623,14 +623,14 @@ class TestEccKey_P384(unittest.TestCase):
         p384 = _curves['p384']
         point = EccPoint(p384.Gx, p384.Gy, 'p384')
         key = EccKey(curve="P-384", point=point)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, point)
 
     def test_public_key_derived(self):
 
         priv_key = EccKey(curve="P-384", d=3)
         pub_key = priv_key.public_key()
-        self.failIf(pub_key.has_private())
+        self.assertFalse(pub_key.has_private())
         self.assertEqual(priv_key.pointQ, pub_key.pointQ)
 
     def test_invalid_curve(self):
@@ -668,14 +668,14 @@ class TestEccKey_P521(unittest.TestCase):
 
         key = EccKey(curve="P-521", d=1)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ.x, p521.Gx)
         self.assertEqual(key.pointQ.y, p521.Gy)
 
         point = EccPoint(p521.Gx, p521.Gy, "p521")
         key = EccKey(curve="P-521", d=1, point=point)
         self.assertEqual(key.d, 1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, point)
 
         # Other names
@@ -688,14 +688,14 @@ class TestEccKey_P521(unittest.TestCase):
         p521 = _curves['p521']
         point = EccPoint(p521.Gx, p521.Gy, 'p521')
         key = EccKey(curve="P-384", point=point)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, point)
 
     def test_public_key_derived(self):
 
         priv_key = EccKey(curve="P-521", d=3)
         pub_key = priv_key.public_key()
-        self.failIf(pub_key.has_private())
+        self.assertFalse(pub_key.has_private())
         self.assertEqual(priv_key.pointQ, pub_key.pointQ)
 
     def test_invalid_curve(self):
@@ -730,7 +730,7 @@ class TestEccModule_P256(unittest.TestCase):
     def test_generate(self):
 
         key = ECC.generate(curve="P-256")
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, EccPoint(_curves['p256'].Gx,
                                               _curves['p256'].Gy) * key.d,
                                               "p256")
@@ -742,12 +742,12 @@ class TestEccModule_P256(unittest.TestCase):
     def test_construct(self):
 
         key = ECC.construct(curve="P-256", d=1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, _curves['p256'].G)
 
         key = ECC.construct(curve="P-256", point_x=_curves['p256'].Gx,
                             point_y=_curves['p256'].Gy)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, _curves['p256'].G)
 
         # Other names
@@ -769,7 +769,7 @@ class TestEccModule_P384(unittest.TestCase):
 
         curve = _curves['p384']
         key = ECC.generate(curve="P-384")
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, EccPoint(curve.Gx, curve.Gy, "p384") * key.d)
 
         # Other names
@@ -780,11 +780,11 @@ class TestEccModule_P384(unittest.TestCase):
 
         curve = _curves['p384']
         key = ECC.construct(curve="P-384", d=1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, _curves['p384'].G)
 
         key = ECC.construct(curve="P-384", point_x=curve.Gx, point_y=curve.Gy)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, curve.G)
 
         # Other names
@@ -806,7 +806,7 @@ class TestEccModule_P521(unittest.TestCase):
 
         curve = _curves['p521']
         key = ECC.generate(curve="P-521")
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, EccPoint(curve.Gx, curve.Gy, "p521") * key.d)
 
         # Other names
@@ -817,11 +817,11 @@ class TestEccModule_P521(unittest.TestCase):
 
         curve = _curves['p521']
         key = ECC.construct(curve="P-521", d=1)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.pointQ, _curves['p521'].G)
 
         key = ECC.construct(curve="P-521", point_x=curve.Gx, point_y=curve.Gy)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.pointQ, curve.G)
 
         # Other names

--- a/lib/Crypto/SelfTest/PublicKey/test_ElGamal.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_ElGamal.py
@@ -101,23 +101,23 @@ class ElGamalTest(unittest.TestCase):
             d = self.convert_tv(tv, True)
             key = ElGamal.construct(d['key'])
             ct = key._encrypt(d['pt'], d['k'])
-            self.assertEquals(ct[0], d['ct1'])
-            self.assertEquals(ct[1], d['ct2'])
+            self.assertEqual(ct[0], d['ct1'])
+            self.assertEqual(ct[1], d['ct2'])
 
     def test_decryption(self):
         for tv in self.tve:
             d = self.convert_tv(tv, True)
             key = ElGamal.construct(d['key'])
             pt = key._decrypt((d['ct1'], d['ct2']))
-            self.assertEquals(pt, d['pt'])
+            self.assertEqual(pt, d['pt'])
 
     def test_signing(self):
         for tv in self.tvs:
             d = self.convert_tv(tv, True)
             key = ElGamal.construct(d['key'])
             sig1, sig2 = key._sign(d['h'], d['k'])
-            self.assertEquals(sig1, d['sig1'])
-            self.assertEquals(sig2, d['sig2'])
+            self.assertEqual(sig1, d['sig1'])
+            self.assertEqual(sig2, d['sig2'])
 
     def test_verification(self):
         for tv in self.tvs:
@@ -125,10 +125,10 @@ class ElGamalTest(unittest.TestCase):
             key = ElGamal.construct(d['key'])
             # Positive test
             res = key._verify( d['h'], (d['sig1'],d['sig2']) )
-            self.failUnless(res)
+            self.assertTrue(res)
             # Negative test
             res = key._verify( d['h'], (d['sig1']+1,d['sig2']) )
-            self.failIf(res)
+            self.assertFalse(res)
 
     def test_bad_key3(self):
         tup = tup0 = list(self.convert_tv(self.tvs[0], 1)['key'])[:3]
@@ -174,29 +174,29 @@ class ElGamalTest(unittest.TestCase):
     def _check_private_key(self, elgObj):
 
         # Check capabilities
-        self.failUnless(elgObj.has_private())
+        self.assertTrue(elgObj.has_private())
 
         # Sanity check key data
-        self.failUnless(1<elgObj.g<(elgObj.p-1))
-        self.assertEquals(pow(elgObj.g, elgObj.p-1, elgObj.p), 1)
-        self.failUnless(1<elgObj.x<(elgObj.p-1))
-        self.assertEquals(pow(elgObj.g, elgObj.x, elgObj.p), elgObj.y)
+        self.assertTrue(1<elgObj.g<(elgObj.p-1))
+        self.assertEqual(pow(elgObj.g, elgObj.p-1, elgObj.p), 1)
+        self.assertTrue(1<elgObj.x<(elgObj.p-1))
+        self.assertEqual(pow(elgObj.g, elgObj.x, elgObj.p), elgObj.y)
 
     def _check_public_key(self, elgObj):
 
         # Check capabilities
-        self.failIf(elgObj.has_private())
+        self.assertFalse(elgObj.has_private())
 
         # Sanity check key data
-        self.failUnless(1<elgObj.g<(elgObj.p-1))
-        self.assertEquals(pow(elgObj.g, elgObj.p-1, elgObj.p), 1)
+        self.assertTrue(1<elgObj.g<(elgObj.p-1))
+        self.assertEqual(pow(elgObj.g, elgObj.p-1, elgObj.p), 1)
 
     def _exercise_primitive(self, elgObj):
         # Test encryption/decryption
         plaintext = 127218
         ciphertext = elgObj._encrypt(plaintext, 123456789)
         plaintextP = elgObj._decrypt(ciphertext)
-        self.assertEquals(plaintext, plaintextP)
+        self.assertEqual(plaintext, plaintextP)
 
         # Test signature/verification
         signature = elgObj._sign(plaintext, 987654321)

--- a/lib/Crypto/SelfTest/PublicKey/test_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_RSA.py
@@ -192,9 +192,9 @@ class RSATest(unittest.TestCase):
 
     def test_factoring(self):
         rsaObj = self.rsa.construct([self.n, self.e, self.d])
-        self.failUnless(rsaObj.p==self.p or rsaObj.p==self.q)
-        self.failUnless(rsaObj.q==self.p or rsaObj.q==self.q)
-        self.failUnless(rsaObj.q*rsaObj.p == self.n)
+        self.assertTrue(rsaObj.p==self.p or rsaObj.p==self.q)
+        self.assertTrue(rsaObj.q==self.p or rsaObj.q==self.q)
+        self.assertTrue(rsaObj.q*rsaObj.p == self.n)
 
         self.assertRaises(ValueError, self.rsa.construct, [self.n, self.e, self.n-1])
 
@@ -221,8 +221,8 @@ class RSATest(unittest.TestCase):
 
     def test_size(self):
         pub = self.rsa.construct((self.n, self.e))
-        self.assertEquals(pub.size_in_bits(), 1024)
-        self.assertEquals(pub.size_in_bytes(), 128)
+        self.assertEqual(pub.size_in_bits(), 1024)
+        self.assertEqual(pub.size_in_bytes(), 128)
 
     def _check_private_key(self, rsaObj):
         from Crypto.Math.Numbers import Integer
@@ -265,7 +265,7 @@ class RSATest(unittest.TestCase):
 
         # Check __eq__ and __ne__
         self.assertEqual(rsaObj.public_key() == rsaObj.public_key(),True) # assert_
-        self.assertEqual(rsaObj.public_key() != rsaObj.public_key(),False) # failIf
+        self.assertEqual(rsaObj.public_key() != rsaObj.public_key(),False) # assertFalse
 
         self.assertEqual(rsaObj.publickey(), rsaObj.public_key())
 

--- a/lib/Crypto/SelfTest/PublicKey/test_import_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_DSA.py
@@ -67,7 +67,7 @@ class ImportKeyTests(unittest.TestCase):
 
     def testImportKey1(self):
         key_obj = DSA.importKey(self.der_public)
-        self.failIf(key_obj.has_private())
+        self.assertFalse(key_obj.has_private())
         self.assertEqual(self.y, key_obj.y)
         self.assertEqual(self.p, key_obj.p)
         self.assertEqual(self.q, key_obj.q)
@@ -97,7 +97,7 @@ tPG+TJKpGYb7pVk=
     def testImportKey2(self):
         for pem in (self.pem_public, tostr(self.pem_public)):
             key_obj = DSA.importKey(pem)
-            self.failIf(key_obj.has_private())
+            self.assertFalse(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -128,7 +128,7 @@ tPG+TJKpGYb7pVk=
 
     def testImportKey3(self):
         key_obj = DSA.importKey(self.der_private)
-        self.failUnless(key_obj.has_private())
+        self.assertTrue(key_obj.has_private())
         self.assertEqual(self.y, key_obj.y)
         self.assertEqual(self.p, key_obj.p)
         self.assertEqual(self.q, key_obj.q)
@@ -159,7 +159,7 @@ ggadmEIJhrMUIVAldWBl
     def testImportKey4(self):
         for pem in (self.pem_private, tostr(self.pem_private)):
             key_obj = DSA.importKey(pem)
-            self.failUnless(key_obj.has_private())
+            self.assertTrue(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -188,7 +188,7 @@ ggadmEIJhrMUIVAldWBl
 
     def testImportKey5(self):
         key_obj = DSA.importKey(self.der_pkcs8)
-        self.failUnless(key_obj.has_private())
+        self.assertTrue(key_obj.has_private())
         self.assertEqual(self.y, key_obj.y)
         self.assertEqual(self.p, key_obj.p)
         self.assertEqual(self.q, key_obj.q)
@@ -218,7 +218,7 @@ tBxWrkP9MA2JJi5O/YmUP5mmUbA4iAQWAhRevZo/C4IGnZhCCYazFCFQJXVgZQ==
     def testImportKey6(self):
         for pem in (self.pem_pkcs8, tostr(self.pem_pkcs8)):
             key_obj = DSA.importKey(pem)
-            self.failUnless(key_obj.has_private())
+            self.assertTrue(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -239,7 +239,7 @@ tBxWrkP9MA2JJi5O/YmUP5mmUbA4iAQWAhRevZo/C4IGnZhCCYazFCFQJXVgZQ==
     def testImportKey7(self):
         for ssh in (self.ssh_pub, tostr(self.ssh_pub)):
             key_obj = DSA.importKey(ssh)
-            self.failIf(key_obj.has_private())
+            self.assertFalse(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -272,7 +272,7 @@ xVJtxaV37m3aXxtCsPnbBg==
     def testImportKey8(self):
         for pem in (self.pem_private_encrypted, tostr(self.pem_private_encrypted)):
             key_obj = DSA.importKey(pem, "PWDTEST")
-            self.failUnless(key_obj.has_private())
+            self.assertTrue(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -307,7 +307,7 @@ eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==
     def testImportKey9(self):
         for pem in (self.pem_pkcs8_encrypted, tostr(self.pem_pkcs8_encrypted)):
             key_obj = DSA.importKey(pem, "PWDTEST")
-            self.failUnless(key_obj.has_private())
+            self.assertTrue(key_obj.has_private())
             self.assertEqual(self.y, key_obj.y)
             self.assertEqual(self.p, key_obj.p)
             self.assertEqual(self.q, key_obj.q)
@@ -336,7 +336,7 @@ eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==
 
     def testImportKey10(self):
         key_obj = DSA.importKey(self.der_pkcs8_encrypted, "PWDTEST")
-        self.failUnless(key_obj.has_private())
+        self.assertTrue(key_obj.has_private())
         self.assertEqual(self.y, key_obj.y)
         self.assertEqual(self.p, key_obj.p)
         self.assertEqual(self.q, key_obj.q)
@@ -364,7 +364,7 @@ eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==
         """Verify importKey is an alias to import_key"""
 
         key_obj = DSA.import_key(self.der_public)
-        self.failIf(key_obj.has_private())
+        self.assertFalse(key_obj.has_private())
         self.assertEqual(self.y, key_obj.y)
         self.assertEqual(self.p, key_obj.p)
         self.assertEqual(self.q, key_obj.q)
@@ -373,7 +373,7 @@ eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==
     def test_exportKey(self):
         tup = (self.y, self.g, self.p, self.q, self.x)
         key = DSA.construct(tup)
-        self.assertEquals(key.exportKey(), key.export_key())
+        self.assertEqual(key.exportKey(), key.export_key())
 
 
     def test_import_empty(self):
@@ -452,7 +452,7 @@ a1:e4:20:fa:55:a8:a7:5c:d2:f0:ea:9a:0c:2e:da:
             comp_str = locals()[comp_name + "_str"]
             comp = int(re.sub("[^0-9a-f]", "", comp_str), 16)
             self.assertEqual(getattr(key, comp_name), comp)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
 
     def test_x509v3(self):
 
@@ -536,7 +536,7 @@ c4:ee:bd:e3:82:e5:9a:2e:3e:b5:e8:01:b5:1d:63:
             comp_str = locals()[comp_name + "_str"]
             comp = int(re.sub("[^0-9a-f]", "", comp_str), 16)
             self.assertEqual(getattr(key, comp_name), comp)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
 
 
 if __name__ == '__main__':

--- a/lib/Crypto/SelfTest/PublicKey/test_import_ECC.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_ECC.py
@@ -662,15 +662,15 @@ class TestExport_P256(unittest.TestCase):
         key_file = load_file("ecc_p256_public_openssh.txt", "rt")
 
         encoded = self.ref_public._export_openssh(False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         # ---
 
         encoded = self.ref_public.export_key(format="OpenSSH")
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         encoded = self.ref_public.export_key(format="OpenSSH", compress=False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
     def test_export_openssh_compressed(self):
         key_file = load_file("ecc_p256_public_openssh.txt", "rt")
@@ -678,7 +678,7 @@ class TestExport_P256(unittest.TestCase):
 
         key_file_compressed = pub_key.export_key(format="OpenSSH", compress=True)
         assert len(key_file) > len(key_file_compressed)
-        self.assertEquals(pub_key, ECC.import_key(key_file_compressed))
+        self.assertEqual(pub_key, ECC.import_key(key_file_compressed))
 
     def test_prng(self):
         # Test that password-protected containers use the provided PRNG
@@ -690,7 +690,7 @@ class TestExport_P256(unittest.TestCase):
                                           passphrase="secret",
                                           protection="PBKDF2WithHMAC-SHA1AndAES128-CBC",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
         # ---
 
@@ -702,7 +702,7 @@ class TestExport_P256(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase="secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_byte_or_string_passphrase(self):
         encoded1 = self.ref_private.export_key(format="PEM",
@@ -713,7 +713,7 @@ class TestExport_P256(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase=b"secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_error_params1(self):
         # Unknown format
@@ -942,15 +942,15 @@ class TestExport_P384(unittest.TestCase):
         key_file = load_file("ecc_p384_public_openssh.txt", "rt")
 
         encoded = self.ref_public._export_openssh(False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         # ---
 
         encoded = self.ref_public.export_key(format="OpenSSH")
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         encoded = self.ref_public.export_key(format="OpenSSH", compress=False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
     def test_export_openssh_compressed(self):
         key_file = load_file("ecc_p384_public_openssh.txt", "rt")
@@ -958,7 +958,7 @@ class TestExport_P384(unittest.TestCase):
 
         key_file_compressed = pub_key.export_key(format="OpenSSH", compress=True)
         assert len(key_file) > len(key_file_compressed)
-        self.assertEquals(pub_key, ECC.import_key(key_file_compressed))
+        self.assertEqual(pub_key, ECC.import_key(key_file_compressed))
 
     def test_prng(self):
         # Test that password-protected containers use the provided PRNG
@@ -970,7 +970,7 @@ class TestExport_P384(unittest.TestCase):
                                           passphrase="secret",
                                           protection="PBKDF2WithHMAC-SHA1AndAES128-CBC",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
         # ---
 
@@ -982,7 +982,7 @@ class TestExport_P384(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase="secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_byte_or_string_passphrase(self):
         encoded1 = self.ref_private.export_key(format="PEM",
@@ -993,7 +993,7 @@ class TestExport_P384(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase=b"secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_error_params1(self):
         # Unknown format
@@ -1211,15 +1211,15 @@ class TestExport_P521(unittest.TestCase):
         key_file = load_file("ecc_p521_public_openssh.txt", "rt")
 
         encoded = self.ref_public._export_openssh(False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         # ---
 
         encoded = self.ref_public.export_key(format="OpenSSH")
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
         encoded = self.ref_public.export_key(format="OpenSSH", compress=False)
-        self.assertEquals(key_file, encoded)
+        self.assertEqual(key_file, encoded)
 
     def test_export_openssh_compressed(self):
         key_file = load_file("ecc_p521_public_openssh.txt", "rt")
@@ -1227,7 +1227,7 @@ class TestExport_P521(unittest.TestCase):
 
         key_file_compressed = pub_key.export_key(format="OpenSSH", compress=True)
         assert len(key_file) > len(key_file_compressed)
-        self.assertEquals(pub_key, ECC.import_key(key_file_compressed))
+        self.assertEqual(pub_key, ECC.import_key(key_file_compressed))
 
     def test_prng(self):
         # Test that password-protected containers use the provided PRNG
@@ -1239,7 +1239,7 @@ class TestExport_P521(unittest.TestCase):
                                           passphrase="secret",
                                           protection="PBKDF2WithHMAC-SHA1AndAES128-CBC",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
         # ---
 
@@ -1251,7 +1251,7 @@ class TestExport_P521(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase="secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_byte_or_string_passphrase(self):
         encoded1 = self.ref_private.export_key(format="PEM",
@@ -1262,7 +1262,7 @@ class TestExport_P521(unittest.TestCase):
                                           use_pkcs8=False,
                                           passphrase=b"secret",
                                           randfunc=get_fixed_prng())
-        self.assertEquals(encoded1, encoded2)
+        self.assertEqual(encoded1, encoded2)
 
     def test_error_params1(self):
         # Unknown format

--- a/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
@@ -188,7 +188,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testImportKey1(self):
         """Verify import of RSAPrivateKey DER SEQUENCE"""
         key = RSA.importKey(self.rsaKeyDER)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
         self.assertEqual(key.d, self.d)
@@ -198,7 +198,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testImportKey2(self):
         """Verify import of SubjectPublicKeyInfo DER SEQUENCE"""
         key = RSA.importKey(self.rsaPublicKeyDER)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
 
@@ -225,14 +225,14 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testImportKey4unicode(self):
         """Verify import of RSAPrivateKey DER SEQUENCE, encoded with PEM as unicode"""
         key = RSA.importKey(self.rsaPublicKeyPEM)
-        self.assertEqual(key.has_private(),False) # failIf
+        self.assertEqual(key.has_private(),False) # assertFalse
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
 
     def testImportKey4bytes(self):
         """Verify import of SubjectPublicKeyInfo DER SEQUENCE, encoded with PEM as byte string"""
         key = RSA.importKey(b(self.rsaPublicKeyPEM))
-        self.assertEqual(key.has_private(),False) # failIf
+        self.assertEqual(key.has_private(),False) # assertFalse
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
 
@@ -258,7 +258,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         """Verify import of encrypted PrivateKeyInfo DER SEQUENCE"""
         for t in self.rsaKeyEncryptedPEM:
             key = RSA.importKey(t[1], t[0])
-            self.failUnless(key.has_private())
+            self.assertTrue(key.has_private())
             self.assertEqual(key.n, self.n)
             self.assertEqual(key.e, self.e)
             self.assertEqual(key.d, self.d)
@@ -268,7 +268,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testImportKey9(self):
         """Verify import of unencrypted PrivateKeyInfo DER SEQUENCE"""
         key = RSA.importKey(self.rsaKeyDER8)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
         self.assertEqual(key.d, self.d)
@@ -278,7 +278,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def testImportKey10(self):
         """Verify import of unencrypted PrivateKeyInfo DER SEQUENCE, encoded with PEM"""
         key = RSA.importKey(self.rsaKeyPEM8)
-        self.failUnless(key.has_private())
+        self.assertTrue(key.has_private())
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
         self.assertEqual(key.d, self.d)
@@ -359,8 +359,8 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         # PEM envelope, PKCS#1, old PEM encryption
         key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
         outkey = key.export_key('PEM', 'test')
-        self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
-        self.failUnless(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
+        self.assertTrue(tostr(outkey).find('4,ENCRYPTED')!=-1)
+        self.assertTrue(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
         inkey = RSA.importKey(outkey, 'test')
         self.assertEqual(key.n, inkey.n)
         self.assertEqual(key.e, inkey.e)
@@ -371,8 +371,8 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         # PEM envelope, PKCS#1, old PEM encryption
         key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
         outkey = key.export_key('PEM', 'test', pkcs=1)
-        self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
-        self.failUnless(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
+        self.assertTrue(tostr(outkey).find('4,ENCRYPTED')!=-1)
+        self.assertTrue(tostr(outkey).find('BEGIN RSA PRIVATE KEY')!=-1)
         inkey = RSA.importKey(outkey, 'test')
         self.assertEqual(key.n, inkey.n)
         self.assertEqual(key.e, inkey.e)
@@ -383,8 +383,8 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         # PEM envelope, PKCS#8, old PEM encryption
         key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
         outkey = key.export_key('PEM', 'test', pkcs=8)
-        self.failUnless(tostr(outkey).find('4,ENCRYPTED')!=-1)
-        self.failUnless(tostr(outkey).find('BEGIN PRIVATE KEY')!=-1)
+        self.assertTrue(tostr(outkey).find('4,ENCRYPTED')!=-1)
+        self.assertTrue(tostr(outkey).find('BEGIN PRIVATE KEY')!=-1)
         inkey = RSA.importKey(outkey, 'test')
         self.assertEqual(key.n, inkey.n)
         self.assertEqual(key.e, inkey.e)
@@ -396,8 +396,8 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
         key = RSA.construct([self.n, self.e, self.d, self.p, self.q, self.pInv])
         outkey = key.export_key('PEM', 'test', pkcs=8,
                 protection='PBKDF2WithHMAC-SHA1AndDES-EDE3-CBC')
-        self.failUnless(tostr(outkey).find('4,ENCRYPTED')==-1)
-        self.failUnless(tostr(outkey).find('BEGIN ENCRYPTED PRIVATE KEY')!=-1)
+        self.assertTrue(tostr(outkey).find('4,ENCRYPTED')==-1)
+        self.assertTrue(tostr(outkey).find('BEGIN ENCRYPTED PRIVATE KEY')!=-1)
         inkey = RSA.importKey(outkey, 'test')
         self.assertEqual(key.n, inkey.n)
         self.assertEqual(key.e, inkey.e)
@@ -422,7 +422,7 @@ Lr7UkvEtFrRhDDKMtuIIq19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQ==
     def test_import_key(self):
         """Verify that import_key is an alias to importKey"""
         key = RSA.import_key(self.rsaPublicKeyDER)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
         self.assertEqual(key.n, self.n)
         self.assertEqual(key.e, self.e)
 
@@ -471,7 +471,7 @@ a3:18:d0:da:95:9f:05:d6:99:37:db:e0:81:b3:c8:
         key = RSA.importKey(x509_v1_cert)
         self.assertEqual(key.e, exponent)
         self.assertEqual(key.n, modulus)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
 
     def test_x509v3(self):
 
@@ -523,7 +523,7 @@ d6:fa:d8:36:42:d4:97:29:17
         key = RSA.importKey(x509_v3_cert)
         self.assertEqual(key.e, exponent)
         self.assertEqual(key.n, modulus)
-        self.failIf(key.has_private())
+        self.assertFalse(key.has_private())
 
 
 class TestImport_2048(unittest.TestCase):

--- a/lib/Crypto/SelfTest/Signature/test_dss.py
+++ b/lib/Crypto/SelfTest/Signature/test_dss.py
@@ -138,10 +138,10 @@ class FIPS_DSA_Tests(unittest.TestCase):
 
         self.description = "can_sign() test"
         signer = DSS.new(self.key_priv, 'fips-186-3')
-        self.failUnless(signer.can_sign())
+        self.assertTrue(signer.can_sign())
 
         signer = DSS.new(self.key_pub, 'fips-186-3')
-        self.failIf(signer.can_sign())
+        self.assertFalse(signer.can_sign())
 
 
 class FIPS_DSA_Tests_KAT(unittest.TestCase):
@@ -248,10 +248,10 @@ class FIPS_ECDSA_Tests(unittest.TestCase):
 
         self.description = "can_sign() test"
         signer = DSS.new(self.key_priv, 'fips-186-3')
-        self.failUnless(signer.can_sign())
+        self.assertTrue(signer.can_sign())
 
         signer = DSS.new(self.key_pub, 'fips-186-3')
-        self.failIf(signer.can_sign())
+        self.assertFalse(signer.can_sign())
 
     def test_negative_unknown_modes_encodings(self):
         """Verify that unknown modes/encodings are rejected"""

--- a/lib/Crypto/SelfTest/Util/test_Padding.py
+++ b/lib/Crypto/SelfTest/Util/test_Padding.py
@@ -42,29 +42,29 @@ class PKCS7_Tests(unittest.TestCase):
 
     def test1(self):
         padded = pad(b(""), 4)
-        self.failUnless(padded == uh(b("04040404")))
+        self.assertTrue(padded == uh(b("04040404")))
         padded = pad(b(""), 4, 'pkcs7')
-        self.failUnless(padded == uh(b("04040404")))
+        self.assertTrue(padded == uh(b("04040404")))
         back = unpad(padded, 4)
-        self.failUnless(back == b(""))
+        self.assertTrue(back == b(""))
 
     def test2(self):
         padded = pad(uh(b("12345678")), 4)
-        self.failUnless(padded == uh(b("1234567804040404")))
+        self.assertTrue(padded == uh(b("1234567804040404")))
         back = unpad(padded, 4)
-        self.failUnless(back == uh(b("12345678")))
+        self.assertTrue(back == uh(b("12345678")))
 
     def test3(self):
         padded = pad(uh(b("123456")), 4)
-        self.failUnless(padded == uh(b("12345601")))
+        self.assertTrue(padded == uh(b("12345601")))
         back = unpad(padded, 4)
-        self.failUnless(back == uh(b("123456")))
+        self.assertTrue(back == uh(b("123456")))
 
     def test4(self):
         padded = pad(uh(b("1234567890")), 4)
-        self.failUnless(padded == uh(b("1234567890030303")))
+        self.assertTrue(padded == uh(b("1234567890030303")))
         back = unpad(padded, 4)
-        self.failUnless(back == uh(b("1234567890")))
+        self.assertTrue(back == uh(b("1234567890")))
 
     def testn1(self):
         self.assertRaises(ValueError, pad, uh(b("12")), 4, 'pkcs8')
@@ -82,27 +82,27 @@ class X923_Tests(unittest.TestCase):
 
     def test1(self):
         padded = pad(b(""), 4, 'x923')
-        self.failUnless(padded == uh(b("00000004")))
+        self.assertTrue(padded == uh(b("00000004")))
         back = unpad(padded, 4, 'x923')
-        self.failUnless(back == b(""))
+        self.assertTrue(back == b(""))
 
     def test2(self):
         padded = pad(uh(b("12345678")), 4, 'x923')
-        self.failUnless(padded == uh(b("1234567800000004")))
+        self.assertTrue(padded == uh(b("1234567800000004")))
         back = unpad(padded, 4, 'x923')
-        self.failUnless(back == uh(b("12345678")))
+        self.assertTrue(back == uh(b("12345678")))
 
     def test3(self):
         padded = pad(uh(b("123456")), 4, 'x923')
-        self.failUnless(padded == uh(b("12345601")))
+        self.assertTrue(padded == uh(b("12345601")))
         back = unpad(padded, 4, 'x923')
-        self.failUnless(back == uh(b("123456")))
+        self.assertTrue(back == uh(b("123456")))
 
     def test4(self):
         padded = pad(uh(b("1234567890")), 4, 'x923')
-        self.failUnless(padded == uh(b("1234567890000003")))
+        self.assertTrue(padded == uh(b("1234567890000003")))
         back = unpad(padded, 4, 'x923')
-        self.failUnless(back == uh(b("1234567890")))
+        self.assertTrue(back == uh(b("1234567890")))
 
     def testn1(self):
         self.assertRaises(ValueError, unpad, b("123456\x02"), 4, 'x923')
@@ -114,28 +114,28 @@ class ISO7816_Tests(unittest.TestCase):
 
     def test1(self):
         padded = pad(b(""), 4, 'iso7816')
-        self.failUnless(padded == uh(b("80000000")))
+        self.assertTrue(padded == uh(b("80000000")))
         back = unpad(padded, 4, 'iso7816')
-        self.failUnless(back == b(""))
+        self.assertTrue(back == b(""))
 
     def test2(self):
         padded = pad(uh(b("12345678")), 4, 'iso7816')
-        self.failUnless(padded == uh(b("1234567880000000")))
+        self.assertTrue(padded == uh(b("1234567880000000")))
         back = unpad(padded, 4, 'iso7816')
-        self.failUnless(back == uh(b("12345678")))
+        self.assertTrue(back == uh(b("12345678")))
 
     def test3(self):
         padded = pad(uh(b("123456")), 4, 'iso7816')
-        self.failUnless(padded == uh(b("12345680")))
+        self.assertTrue(padded == uh(b("12345680")))
         #import pdb; pdb.set_trace()
         back = unpad(padded, 4, 'iso7816')
-        self.failUnless(back == uh(b("123456")))
+        self.assertTrue(back == uh(b("123456")))
 
     def test4(self):
         padded = pad(uh(b("1234567890")), 4, 'iso7816')
-        self.failUnless(padded == uh(b("1234567890800000")))
+        self.assertTrue(padded == uh(b("1234567890800000")))
         back = unpad(padded, 4, 'iso7816')
-        self.failUnless(back == uh(b("1234567890")))
+        self.assertTrue(back == uh(b("1234567890")))
 
     def testn1(self):
         self.assertRaises(ValueError, unpad, b("123456\x81"), 4, 'iso7816')

--- a/lib/Crypto/SelfTest/Util/test_asn1.py
+++ b/lib/Crypto/SelfTest/Util/test_asn1.py
@@ -54,40 +54,40 @@ class DerObjectTests(unittest.TestCase):
     def testObjEncode1(self):
         # No payload
         der = DerObject(b('\x02'))
-        self.assertEquals(der.encode(), b('\x02\x00'))
+        self.assertEqual(der.encode(), b('\x02\x00'))
         # Small payload (primitive)
         der.payload = b('\x45')
-        self.assertEquals(der.encode(), b('\x02\x01\x45'))
+        self.assertEqual(der.encode(), b('\x02\x01\x45'))
         # Invariant
-        self.assertEquals(der.encode(), b('\x02\x01\x45'))
+        self.assertEqual(der.encode(), b('\x02\x01\x45'))
         # Initialize with numerical tag
         der = DerObject(0x04)
         der.payload = b('\x45')
-        self.assertEquals(der.encode(), b('\x04\x01\x45'))
+        self.assertEqual(der.encode(), b('\x04\x01\x45'))
         # Initialize with constructed type
         der = DerObject(b('\x10'), constructed=True)
-        self.assertEquals(der.encode(), b('\x30\x00'))
+        self.assertEqual(der.encode(), b('\x30\x00'))
 
     def testObjEncode2(self):
         # Initialize with payload
         der = DerObject(0x03, b('\x12\x12'))
-        self.assertEquals(der.encode(), b('\x03\x02\x12\x12'))
+        self.assertEqual(der.encode(), b('\x03\x02\x12\x12'))
 
     def testObjEncode3(self):
         # Long payload
         der = DerObject(b('\x10'))
         der.payload = b("0")*128
-        self.assertEquals(der.encode(), b('\x10\x81\x80' + "0"*128))
+        self.assertEqual(der.encode(), b('\x10\x81\x80' + "0"*128))
 
     def testObjEncode4(self):
         # Implicit tags (constructed)
         der = DerObject(0x10, implicit=1, constructed=True)
         der.payload = b('ppll')
-        self.assertEquals(der.encode(), b('\xa1\x04ppll'))
+        self.assertEqual(der.encode(), b('\xa1\x04ppll'))
         # Implicit tags (primitive)
         der = DerObject(0x02, implicit=0x1E, constructed=False)
         der.payload = b('ppll')
-        self.assertEquals(der.encode(), b('\x9E\x04ppll'))
+        self.assertEqual(der.encode(), b('\x9E\x04ppll'))
 
     def testObjEncode5(self):
         # Encode type with explicit tag
@@ -101,15 +101,15 @@ class DerObjectTests(unittest.TestCase):
         # Decode short payload
         der = DerObject(0x02)
         der.decode(b('\x02\x02\x01\x02'))
-        self.assertEquals(der.payload, b("\x01\x02"))
-        self.assertEquals(der._tag_octet, 0x02)
+        self.assertEqual(der.payload, b("\x01\x02"))
+        self.assertEqual(der._tag_octet, 0x02)
 
     def testObjDecode2(self):
         # Decode long payload
         der = DerObject(0x02)
         der.decode(b('\x02\x81\x80' + "1"*128))
-        self.assertEquals(der.payload, b("1")*128)
-        self.assertEquals(der._tag_octet, 0x02)
+        self.assertEqual(der.payload, b("1")*128)
+        self.assertEqual(der._tag_octet, 0x02)
 
     def testObjDecode3(self):
         # Decode payload with too much data gives error
@@ -124,12 +124,12 @@ class DerObjectTests(unittest.TestCase):
         der = DerObject(0x02, constructed=False, implicit=0xF)
         self.assertRaises(ValueError, der.decode, b('\x02\x02\x01\x02'))
         der.decode(b('\x8F\x01\x00'))
-        self.assertEquals(der.payload, b('\x00'))
+        self.assertEqual(der.payload, b('\x00'))
         # Decode implicit tag (constructed)
         der = DerObject(0x02, constructed=True, implicit=0xF)
         self.assertRaises(ValueError, der.decode, b('\x02\x02\x01\x02'))
         der.decode(b('\xAF\x01\x00'))
-        self.assertEquals(der.payload, b('\x00'))
+        self.assertEqual(der.payload, b('\x00'))
 
     def testObjDecode5(self):
         # Decode payload with unexpected tag gives error
@@ -140,21 +140,21 @@ class DerObjectTests(unittest.TestCase):
         # Arbitrary DER object
         der = DerObject()
         der.decode(b('\x65\x01\x88'))
-        self.assertEquals(der._tag_octet, 0x65)
-        self.assertEquals(der.payload, b('\x88'))
+        self.assertEqual(der._tag_octet, 0x65)
+        self.assertEqual(der.payload, b('\x88'))
 
     def testObjDecode7(self):
         # Decode explicit tag
         der = DerObject(0x10, explicit=5)
         der.decode(b("\xa5\x06\x10\x04xxll"))
-        self.assertEquals(der._inner_tag_octet, 0x10)
-        self.assertEquals(der.payload, b('xxll'))
+        self.assertEqual(der._inner_tag_octet, 0x10)
+        self.assertEqual(der.payload, b('xxll'))
 
         # Explicit tag may be 0
         der = DerObject(0x10, explicit=0)
         der.decode(b("\xa0\x06\x10\x04xxll"))
-        self.assertEquals(der._inner_tag_octet, 0x10)
-        self.assertEquals(der.payload, b('xxll'))
+        self.assertEqual(der._inner_tag_octet, 0x10)
+        self.assertEqual(der.payload, b('xxll'))
 
     def testObjDecode8(self):
         # Verify that decode returns the object
@@ -165,31 +165,31 @@ class DerIntegerTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerInteger(1)
-        self.assertEquals(der.encode(), b('\x02\x01\x01'))
+        self.assertEqual(der.encode(), b('\x02\x01\x01'))
 
     def testEncode1(self):
         # Single-byte integers
         # Value 0
         der = DerInteger(0)
-        self.assertEquals(der.encode(), b('\x02\x01\x00'))
+        self.assertEqual(der.encode(), b('\x02\x01\x00'))
         # Value 1
         der = DerInteger(1)
-        self.assertEquals(der.encode(), b('\x02\x01\x01'))
+        self.assertEqual(der.encode(), b('\x02\x01\x01'))
         # Value 127
         der = DerInteger(127)
-        self.assertEquals(der.encode(), b('\x02\x01\x7F'))
+        self.assertEqual(der.encode(), b('\x02\x01\x7F'))
 
     def testEncode2(self):
         # Multi-byte integers
         # Value 128
         der = DerInteger(128)
-        self.assertEquals(der.encode(), b('\x02\x02\x00\x80'))
+        self.assertEqual(der.encode(), b('\x02\x02\x00\x80'))
         # Value 0x180
         der = DerInteger(0x180)
-        self.assertEquals(der.encode(), b('\x02\x02\x01\x80'))
+        self.assertEqual(der.encode(), b('\x02\x02\x01\x80'))
         # One very long integer
         der = DerInteger(2**2048)
-        self.assertEquals(der.encode(),
+        self.assertEqual(der.encode(),
         b('\x02\x82\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
@@ -214,18 +214,18 @@ class DerIntegerTests(unittest.TestCase):
         # Negative integers
         # Value -1
         der = DerInteger(-1)
-        self.assertEquals(der.encode(), b('\x02\x01\xFF'))
+        self.assertEqual(der.encode(), b('\x02\x01\xFF'))
         # Value -128
         der = DerInteger(-128)
-        self.assertEquals(der.encode(), b('\x02\x01\x80'))
+        self.assertEqual(der.encode(), b('\x02\x01\x80'))
         # Value
         der = DerInteger(-87873)
-        self.assertEquals(der.encode(), b('\x02\x03\xFE\xA8\xBF'))
+        self.assertEqual(der.encode(), b('\x02\x03\xFE\xA8\xBF'))
 
     def testEncode4(self):
         # Explicit encoding
         number = DerInteger(0x34, explicit=3)
-        self.assertEquals(number.encode(), b('\xa3\x03\x02\x01\x34'))
+        self.assertEqual(number.encode(), b('\xa3\x03\x02\x01\x34'))
 
     # -----
 
@@ -234,20 +234,20 @@ class DerIntegerTests(unittest.TestCase):
         der = DerInteger()
         # Value 0
         der.decode(b('\x02\x01\x00'))
-        self.assertEquals(der.value, 0)
+        self.assertEqual(der.value, 0)
         # Value 1
         der.decode(b('\x02\x01\x01'))
-        self.assertEquals(der.value, 1)
+        self.assertEqual(der.value, 1)
         # Value 127
         der.decode(b('\x02\x01\x7F'))
-        self.assertEquals(der.value, 127)
+        self.assertEqual(der.value, 127)
 
     def testDecode2(self):
         # Multi-byte integer
         der = DerInteger()
         # Value 0x180L
         der.decode(b('\x02\x02\x01\x80'))
-        self.assertEquals(der.value,0x180)
+        self.assertEqual(der.value,0x180)
         # One very long integer
         der.decode(
         b('\x02\x82\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
@@ -269,41 +269,41 @@ class DerIntegerTests(unittest.TestCase):
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00'))
-        self.assertEquals(der.value,2**2048)
+        self.assertEqual(der.value,2**2048)
 
     def testDecode3(self):
         # Negative integer
         der = DerInteger()
         # Value -1
         der.decode(b('\x02\x01\xFF'))
-        self.assertEquals(der.value, -1)
+        self.assertEqual(der.value, -1)
         # Value -32768
         der.decode(b('\x02\x02\x80\x00'))
-        self.assertEquals(der.value, -32768)
+        self.assertEqual(der.value, -32768)
 
     def testDecode5(self):
         # We still accept BER integer format
         der = DerInteger()
         # Redundant leading zeroes
         der.decode(b('\x02\x02\x00\x01'))
-        self.assertEquals(der.value, 1)
+        self.assertEqual(der.value, 1)
         # Redundant leading 0xFF
         der.decode(b('\x02\x02\xFF\xFF'))
-        self.assertEquals(der.value, -1)
+        self.assertEqual(der.value, -1)
         # Empty payload
         der.decode(b('\x02\x00'))
-        self.assertEquals(der.value, 0)
+        self.assertEqual(der.value, 0)
 
     def testDecode6(self):
         # Explicit encoding
         number = DerInteger(explicit=3)
         number.decode(b('\xa3\x03\x02\x01\x34'))
-        self.assertEquals(number.value, 0x34)
+        self.assertEqual(number.value, 0x34)
 
     def testDecode7(self):
         # Verify decode returns the DerInteger
         der = DerInteger()
-        self.assertEquals(der, der.decode(b('\x02\x01\x7F')))
+        self.assertEqual(der, der.decode(b('\x02\x01\x7F')))
 
     ###
 
@@ -327,49 +327,49 @@ class DerSequenceTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerSequence([1, DerInteger(2), b('0\x00')])
-        self.assertEquals(der.encode(), b('0\x08\x02\x01\x01\x02\x01\x020\x00'))
+        self.assertEqual(der.encode(), b('0\x08\x02\x01\x01\x02\x01\x020\x00'))
 
     def testEncode1(self):
         # Empty sequence
         der = DerSequence()
-        self.assertEquals(der.encode(), b('0\x00'))
-        self.failIf(der.hasOnlyInts())
+        self.assertEqual(der.encode(), b('0\x00'))
+        self.assertFalse(der.hasOnlyInts())
         # One single-byte integer (zero)
         der.append(0)
-        self.assertEquals(der.encode(), b('0\x03\x02\x01\x00'))
-        self.assertEquals(der.hasInts(),1)
-        self.assertEquals(der.hasInts(False),1)
-        self.failUnless(der.hasOnlyInts())
-        self.failUnless(der.hasOnlyInts(False))
+        self.assertEqual(der.encode(), b('0\x03\x02\x01\x00'))
+        self.assertEqual(der.hasInts(),1)
+        self.assertEqual(der.hasInts(False),1)
+        self.assertTrue(der.hasOnlyInts())
+        self.assertTrue(der.hasOnlyInts(False))
         # Invariant
-        self.assertEquals(der.encode(), b('0\x03\x02\x01\x00'))
+        self.assertEqual(der.encode(), b('0\x03\x02\x01\x00'))
 
     def testEncode2(self):
         # Indexing
         der = DerSequence()
         der.append(0)
         der[0] = 1
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],1)
-        self.assertEquals(der[-1],1)
-        self.assertEquals(der.encode(), b('0\x03\x02\x01\x01'))
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],1)
+        self.assertEqual(der[-1],1)
+        self.assertEqual(der.encode(), b('0\x03\x02\x01\x01'))
         #
         der[:] = [1]
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],1)
-        self.assertEquals(der.encode(), b('0\x03\x02\x01\x01'))
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],1)
+        self.assertEqual(der.encode(), b('0\x03\x02\x01\x01'))
 
     def testEncode3(self):
         # One multi-byte integer (non-zero)
         der = DerSequence()
         der.append(0x180)
-        self.assertEquals(der.encode(), b('0\x04\x02\x02\x01\x80'))
+        self.assertEqual(der.encode(), b('0\x04\x02\x02\x01\x80'))
 
     def testEncode4(self):
         # One very long integer
         der = DerSequence()
         der.append(2**2048)
-        self.assertEquals(der.encode(), b('0\x82\x01\x05')+
+        self.assertEqual(der.encode(), b('0\x82\x01\x05')+
         b('\x02\x82\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
@@ -394,48 +394,48 @@ class DerSequenceTests(unittest.TestCase):
         der = DerSequence()
         der += 1
         der += b('\x30\x00')
-        self.assertEquals(der.encode(), b('\x30\x05\x02\x01\x01\x30\x00'))
+        self.assertEqual(der.encode(), b('\x30\x05\x02\x01\x01\x30\x00'))
 
     def testEncode6(self):
         # Two positive integers
         der = DerSequence()
         der.append(0x180)
         der.append(0xFF)
-        self.assertEquals(der.encode(), b('0\x08\x02\x02\x01\x80\x02\x02\x00\xff'))
-        self.failUnless(der.hasOnlyInts())
-        self.failUnless(der.hasOnlyInts(False))
+        self.assertEqual(der.encode(), b('0\x08\x02\x02\x01\x80\x02\x02\x00\xff'))
+        self.assertTrue(der.hasOnlyInts())
+        self.assertTrue(der.hasOnlyInts(False))
         # Two mixed integers
         der = DerSequence()
         der.append(2)
         der.append(-2)
-        self.assertEquals(der.encode(), b('0\x06\x02\x01\x02\x02\x01\xFE'))
-        self.assertEquals(der.hasInts(), 1)
-        self.assertEquals(der.hasInts(False), 2)
-        self.failIf(der.hasOnlyInts())
-        self.failUnless(der.hasOnlyInts(False))
+        self.assertEqual(der.encode(), b('0\x06\x02\x01\x02\x02\x01\xFE'))
+        self.assertEqual(der.hasInts(), 1)
+        self.assertEqual(der.hasInts(False), 2)
+        self.assertFalse(der.hasOnlyInts())
+        self.assertTrue(der.hasOnlyInts(False))
         #
         der.append(0x01)
         der[1:] = [9,8]
-        self.assertEquals(len(der),3)
+        self.assertEqual(len(der),3)
         self.assertEqual(der[1:],[9,8])
         self.assertEqual(der[1:-1],[9])
-        self.assertEquals(der.encode(), b('0\x09\x02\x01\x02\x02\x01\x09\x02\x01\x08'))
+        self.assertEqual(der.encode(), b('0\x09\x02\x01\x02\x02\x01\x09\x02\x01\x08'))
 
     def testEncode7(self):
         # One integer and another type (already encoded)
         der = DerSequence()
         der.append(0x180)
         der.append(b('0\x03\x02\x01\x05'))
-        self.assertEquals(der.encode(), b('0\x09\x02\x02\x01\x800\x03\x02\x01\x05'))
-        self.failIf(der.hasOnlyInts())
+        self.assertEqual(der.encode(), b('0\x09\x02\x02\x01\x800\x03\x02\x01\x05'))
+        self.assertFalse(der.hasOnlyInts())
 
     def testEncode8(self):
         # One integer and another type (yet to encode)
         der = DerSequence()
         der.append(0x180)
         der.append(DerSequence([5]))
-        self.assertEquals(der.encode(), b('0\x09\x02\x02\x01\x800\x03\x02\x01\x05'))
-        self.failIf(der.hasOnlyInts())
+        self.assertEqual(der.encode(), b('0\x09\x02\x02\x01\x800\x03\x02\x01\x05'))
+        self.assertFalse(der.hasOnlyInts())
 
     ####
 
@@ -443,22 +443,22 @@ class DerSequenceTests(unittest.TestCase):
         # Empty sequence
         der = DerSequence()
         der.decode(b('0\x00'))
-        self.assertEquals(len(der),0)
+        self.assertEqual(len(der),0)
         # One single-byte integer (zero)
         der.decode(b('0\x03\x02\x01\x00'))
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],0)
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],0)
         # Invariant
         der.decode(b('0\x03\x02\x01\x00'))
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],0)
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],0)
 
     def testDecode2(self):
         # One single-byte integer (non-zero)
         der = DerSequence()
         der.decode(b('0\x03\x02\x01\x7f'))
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],127)
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],127)
 
     def testDecode4(self):
         # One very long integer
@@ -483,37 +483,37 @@ class DerSequenceTests(unittest.TestCase):
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')+
         b('\x00\x00\x00\x00\x00\x00\x00\x00\x00'))
-        self.assertEquals(len(der),1)
-        self.assertEquals(der[0],2**2048)
+        self.assertEqual(len(der),1)
+        self.assertEqual(der[0],2**2048)
 
     def testDecode6(self):
         # Two integers
         der = DerSequence()
         der.decode(b('0\x08\x02\x02\x01\x80\x02\x02\x00\xff'))
-        self.assertEquals(len(der),2)
-        self.assertEquals(der[0],0x180)
-        self.assertEquals(der[1],0xFF)
+        self.assertEqual(len(der),2)
+        self.assertEqual(der[0],0x180)
+        self.assertEqual(der[1],0xFF)
 
     def testDecode7(self):
         # One integer and 2 other types
         der = DerSequence()
         der.decode(b('0\x0A\x02\x02\x01\x80\x24\x02\xb6\x63\x12\x00'))
-        self.assertEquals(len(der),3)
-        self.assertEquals(der[0],0x180)
-        self.assertEquals(der[1],b('\x24\x02\xb6\x63'))
-        self.assertEquals(der[2],b('\x12\x00'))
+        self.assertEqual(len(der),3)
+        self.assertEqual(der[0],0x180)
+        self.assertEqual(der[1],b('\x24\x02\xb6\x63'))
+        self.assertEqual(der[2],b('\x12\x00'))
 
     def testDecode8(self):
         # Only 2 other types
         der = DerSequence()
         der.decode(b('0\x06\x24\x02\xb6\x63\x12\x00'))
-        self.assertEquals(len(der),2)
-        self.assertEquals(der[0],b('\x24\x02\xb6\x63'))
-        self.assertEquals(der[1],b('\x12\x00'))
-        self.assertEquals(der.hasInts(), 0)
-        self.assertEquals(der.hasInts(False), 0)
-        self.failIf(der.hasOnlyInts())
-        self.failIf(der.hasOnlyInts(False))
+        self.assertEqual(len(der),2)
+        self.assertEqual(der[0],b('\x24\x02\xb6\x63'))
+        self.assertEqual(der[1],b('\x12\x00'))
+        self.assertEqual(der.hasInts(), 0)
+        self.assertEqual(der.hasInts(False), 0)
+        self.assertFalse(der.hasOnlyInts())
+        self.assertFalse(der.hasOnlyInts(False))
 
     def testDecode9(self):
         # Verify that decode returns itself
@@ -566,15 +566,15 @@ class DerOctetStringTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerOctetString(b('\xFF'))
-        self.assertEquals(der.encode(), b('\x04\x01\xFF'))
+        self.assertEqual(der.encode(), b('\x04\x01\xFF'))
 
     def testEncode1(self):
         # Empty sequence
         der = DerOctetString()
-        self.assertEquals(der.encode(), b('\x04\x00'))
+        self.assertEqual(der.encode(), b('\x04\x00'))
         # Small payload
         der.payload = b('\x01\x02')
-        self.assertEquals(der.encode(), b('\x04\x02\x01\x02'))
+        self.assertEqual(der.encode(), b('\x04\x02\x01\x02'))
 
     ####
 
@@ -582,10 +582,10 @@ class DerOctetStringTests(unittest.TestCase):
         # Empty sequence
         der = DerOctetString()
         der.decode(b('\x04\x00'))
-        self.assertEquals(der.payload, b(''))
+        self.assertEqual(der.payload, b(''))
         # Small payload
         der.decode(b('\x04\x02\x01\x02'))
-        self.assertEquals(der.payload, b('\x01\x02'))
+        self.assertEqual(der.payload, b('\x01\x02'))
 
     def testDecode2(self):
         # Verify that decode returns the object
@@ -601,28 +601,28 @@ class DerNullTests(unittest.TestCase):
 
     def testEncode1(self):
         der = DerNull()
-        self.assertEquals(der.encode(), b('\x05\x00'))
+        self.assertEqual(der.encode(), b('\x05\x00'))
 
     ####
 
     def testDecode1(self):
         # Empty sequence
         der = DerNull()
-        self.assertEquals(der, der.decode(b('\x05\x00')))
+        self.assertEqual(der, der.decode(b('\x05\x00')))
 
 class DerObjectIdTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerObjectId("1.1")
-        self.assertEquals(der.encode(), b('\x06\x01)'))
+        self.assertEqual(der.encode(), b('\x06\x01)'))
 
     def testEncode1(self):
         der = DerObjectId('1.2.840.113549.1.1.1')
-        self.assertEquals(der.encode(), b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01'))
+        self.assertEqual(der.encode(), b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01'))
         #
         der = DerObjectId()
         der.value = '1.2.840.113549.1.1.1'
-        self.assertEquals(der.encode(), b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01'))
+        self.assertEqual(der.encode(), b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01'))
 
     ####
 
@@ -630,41 +630,41 @@ class DerObjectIdTests(unittest.TestCase):
         # Empty sequence
         der = DerObjectId()
         der.decode(b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01'))
-        self.assertEquals(der.value, '1.2.840.113549.1.1.1')
+        self.assertEqual(der.value, '1.2.840.113549.1.1.1')
 
     def testDecode2(self):
         # Verify that decode returns the object
         der = DerObjectId()
-        self.assertEquals(der,
+        self.assertEqual(der,
                 der.decode(b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01')))
 
     def testDecode3(self):
         der = DerObjectId()
         der.decode(b('\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x00\x01'))
-        self.assertEquals(der.value, '1.2.840.113549.1.0.1')
+        self.assertEqual(der.value, '1.2.840.113549.1.0.1')
 
 
 class DerBitStringTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerBitString(b("\xFF"))
-        self.assertEquals(der.encode(), b('\x03\x02\x00\xFF'))
+        self.assertEqual(der.encode(), b('\x03\x02\x00\xFF'))
 
     def testInit2(self):
         der = DerBitString(DerInteger(1))
-        self.assertEquals(der.encode(), b('\x03\x04\x00\x02\x01\x01'))
+        self.assertEqual(der.encode(), b('\x03\x04\x00\x02\x01\x01'))
 
     def testEncode1(self):
         # Empty sequence
         der = DerBitString()
-        self.assertEquals(der.encode(), b('\x03\x01\x00'))
+        self.assertEqual(der.encode(), b('\x03\x01\x00'))
         # Small payload
         der = DerBitString(b('\x01\x02'))
-        self.assertEquals(der.encode(), b('\x03\x03\x00\x01\x02'))
+        self.assertEqual(der.encode(), b('\x03\x03\x00\x01\x02'))
         # Small payload
         der = DerBitString()
         der.value = b('\x01\x02')
-        self.assertEquals(der.encode(), b('\x03\x03\x00\x01\x02'))
+        self.assertEqual(der.encode(), b('\x03\x03\x00\x01\x02'))
 
     ####
 
@@ -672,42 +672,42 @@ class DerBitStringTests(unittest.TestCase):
         # Empty sequence
         der = DerBitString()
         der.decode(b('\x03\x00'))
-        self.assertEquals(der.value, b(''))
+        self.assertEqual(der.value, b(''))
         # Small payload
         der.decode(b('\x03\x03\x00\x01\x02'))
-        self.assertEquals(der.value, b('\x01\x02'))
+        self.assertEqual(der.value, b('\x01\x02'))
 
     def testDecode2(self):
         # Verify that decode returns the object
         der = DerBitString()
-        self.assertEquals(der, der.decode(b('\x03\x00')))
+        self.assertEqual(der, der.decode(b('\x03\x00')))
 
 
 class DerSetOfTests(unittest.TestCase):
 
     def testInit1(self):
         der = DerSetOf([DerInteger(1), DerInteger(2)])
-        self.assertEquals(der.encode(), b('1\x06\x02\x01\x01\x02\x01\x02'))
+        self.assertEqual(der.encode(), b('1\x06\x02\x01\x01\x02\x01\x02'))
 
     def testEncode1(self):
         # Empty set
         der = DerSetOf()
-        self.assertEquals(der.encode(), b('1\x00'))
+        self.assertEqual(der.encode(), b('1\x00'))
         # One single-byte integer (zero)
         der.add(0)
-        self.assertEquals(der.encode(), b('1\x03\x02\x01\x00'))
+        self.assertEqual(der.encode(), b('1\x03\x02\x01\x00'))
         # Invariant
-        self.assertEquals(der.encode(), b('1\x03\x02\x01\x00'))
+        self.assertEqual(der.encode(), b('1\x03\x02\x01\x00'))
 
     def testEncode2(self):
         # Two integers
         der = DerSetOf()
         der.add(0x180)
         der.add(0xFF)
-        self.assertEquals(der.encode(), b('1\x08\x02\x02\x00\xff\x02\x02\x01\x80'))
+        self.assertEqual(der.encode(), b('1\x08\x02\x02\x00\xff\x02\x02\x01\x80'))
         # Initialize with integers
         der = DerSetOf([0x180, 0xFF])
-        self.assertEquals(der.encode(), b('1\x08\x02\x02\x00\xff\x02\x02\x01\x80'))
+        self.assertEqual(der.encode(), b('1\x08\x02\x02\x00\xff\x02\x02\x01\x80'))
 
     def testEncode3(self):
         # One integer and another type (no matter what it is)
@@ -720,7 +720,7 @@ class DerSetOfTests(unittest.TestCase):
         der = DerSetOf()
         der.add(b('\x01\x00'))
         der.add(b('\x01\x01\x01'))
-        self.assertEquals(der.encode(), b('1\x05\x01\x00\x01\x01\x01'))
+        self.assertEqual(der.encode(), b('1\x05\x01\x00\x01\x01\x01'))
 
     ####
 
@@ -728,20 +728,20 @@ class DerSetOfTests(unittest.TestCase):
         # Empty sequence
         der = DerSetOf()
         der.decode(b('1\x00'))
-        self.assertEquals(len(der),0)
+        self.assertEqual(len(der),0)
         # One single-byte integer (zero)
         der.decode(b('1\x03\x02\x01\x00'))
-        self.assertEquals(len(der),1)
-        self.assertEquals(list(der),[0])
+        self.assertEqual(len(der),1)
+        self.assertEqual(list(der),[0])
 
     def testDecode2(self):
         # Two integers
         der = DerSetOf()
         der.decode(b('1\x08\x02\x02\x01\x80\x02\x02\x00\xff'))
-        self.assertEquals(len(der),2)
+        self.assertEqual(len(der),2)
         l = list(der)
-        self.failUnless(0x180 in l)
-        self.failUnless(0xFF in l)
+        self.assertTrue(0x180 in l)
+        self.assertTrue(0xFF in l)
 
     def testDecode3(self):
         # One integer and 2 other types
@@ -753,7 +753,7 @@ class DerSetOfTests(unittest.TestCase):
     def testDecode4(self):
         # Verify that decode returns the object
         der = DerSetOf()
-        self.assertEquals(der,
+        self.assertEqual(der,
                 der.decode(b('1\x08\x02\x02\x01\x80\x02\x02\x00\xff')))
 
     ###


### PR DESCRIPTION
Ref : https://github.com/python/cpython/pull/28268 . Aliases are present in Python 2.7 too. So the PR is backwards compatible and is a straightforward find and replace.

```
perl -pi -e 's/assertEquals/assertEqual/g' **/*py
perl -pi -e 's/failIf/assertFalse/g' **/*py
perl -pi -e 's/failUnless/assertTrue/g' **/*py
```

Command to find aliases : 

```
rg -t py 'assertEquals|assertNotEquals|assertAlmostEquals|assertNotAlmostEquals|assertRegexpMatches|assertNotRegexpMatches|assertRaisesRegexp|failUnlessEqual|failIfEqual|failUnlessAlmostEqual|failUnless|failUnlessRaises|failIf'
```