### PR TITLE
Declare support for Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -509,6 +509,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     license="BSD, Public Domain",
     packages=packages,


### PR DESCRIPTION
Add Trove classifier so it shows up on PyPI and through the PyPI API.
