### PR TITLE
C Tests: Avoid creating a 0-length array

### DIFF
--- a/src/test/make_tests_poly1305_load_m.py
+++ b/src/test/make_tests_poly1305_load_m.py
@@ -35,7 +35,7 @@ print("#include <stdio.h>")
 print()
 print("void poly1305_load_m(uint32_t r[5], const uint8_t data[], size_t len);")
 
-for len_secret in range(16+1):
+for len_secret in range(1, 16+1):
     make_test(b"\xaa" * len_secret)
 make_test(b"\xcc" * 16)
 make_test(b"\xff" * 16)


### PR DESCRIPTION
C does not permit 0-length arrays, triggering this warning (raised to an error with `-Werror`) from GCC 11:

```
build/test_poly1305_load_m.c:16:5: error: ‘poly1305_load_m’ reading 1 byte from a region of size 0 [-Werror=stringop-overread]
   16 |     poly1305_load_m(m, secret, 0);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```