### PR TITLE
Respect LDFLAGS in C tests

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -47,19 +47,19 @@ build/modexp_utils.o: ../modexp_utils.c
 TABLES = build/p256_table.o build/p384_table.o build/p521_table.o
 
 build/p256_table.o: ../p256_table.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $^
 
 build/p384_table.o: ../p384_table.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $^
 
 build/p521_table.o: ../p521_table.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -c -o $@ $^
 
 build/tests_ec_ws_64: test_ec_ws.c ../ec_ws.c build/mont_64.o $(TABLES) $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 build/tests_ec_ws_32: test_ec_ws.c ../ec_ws.c build/mont_32.o $(TABLES) $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^ -DSYS_BITS=32 -UHAVE_UINT128
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^ -DSYS_BITS=32 -UHAVE_UINT128
 
 # addmul128
 
@@ -67,10 +67,10 @@ build/tests_addmul128.c: make_tests_addmul128.py
 	python $^ > $@
 
 build/tests_addmul128_32: build/tests_addmul128.c ../multiply_32.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 build/tests_addmul128_64: build/tests_addmul128.c ../multiply_64.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 # square
 
@@ -78,15 +78,15 @@ build/tests_square.c: make_tests_square.py
 	python $^ > $@
 
 build/tests_square_32: build/tests_square.c ../multiply_32.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 build/tests_square_64: build/tests_square.c ../multiply_64.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 # endianess
 
 build/test_endianess: test_endianess.c ../common.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $<
 
 # clmul
 
@@ -94,7 +94,7 @@ build/clmul.o: ../ghash_clmul.c
 	$(CC) $(CFLAGS) -mssse3 -mpclmul $(CPPFLAGS) -o $@ $< -c
 
 build/test_clmul: test_clmul.c ../common.h build/clmul.o
-	$(CC) $(CFLAGS) -mssse3 -mpclmul $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) -mssse3 -mpclmul $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 # Poly1305
 
@@ -117,49 +117,49 @@ build/test_poly1305_accumulate.c: make_tests_poly1305_accumulate.py
 	python $^ > $@
 
 build/test_poly1305_reduce: build/test_poly1305_reduce.c ../common.h build/poly1305.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 build/test_poly1305_load_r: build/test_poly1305_load_r.c ../common.h build/poly1305.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 build/test_poly1305_load_m: build/test_poly1305_load_m.c ../common.h build/poly1305.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 build/test_poly1305_multiply: build/test_poly1305_multiply.c ../common.h build/poly1305.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 build/test_poly1305_accumulate: build/test_poly1305_accumulate.c ../common.h build/poly1305.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 # Montgomery
 
 build/mont_32.o: ../mont.c
-	$(CC) -c $(CFLAGS) $(CPPFLAGS) -o $@ $^ -DSYS_BITS=32 -UHAVE_UINT128
+	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^ -DSYS_BITS=32 -UHAVE_UINT128
 
 build/mont_64.o: ../mont.c
-	$(CC) -c $(CFLAGS) $(CPPFLAGS) -o $@ $^ -DSYS_BITS=64
+	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^ -DSYS_BITS=64
 
 build/test_mont: test_mont.c ../common.h build/mont_32.o $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $(filter %.c %.o, $^)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(filter %.c %.o, $^)
 
 build/tests_addmul.c: make_tests_addmul.py
 	python $^ > $@
 
 build/tests_addmul: build/tests_addmul.c build/mont_32.o $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 build/tests_product.c: make_tests_product.py
 	python $^ > $@
 
 build/tests_product: build/tests_product.c build/mont_32.o $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 build/tests_mont_mult.c: make_tests_mont_mult.py
 	python $^ > $@
 
 build/tests_mont_mult: build/tests_mont_mult.c build/mont_32.o $(UTILS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^
 
 # pkcs1
 build/test_pkcs1: test_pkcs1.c ../common.h ../pkcs1_decode.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $^


### PR DESCRIPTION
Debian's build infrastructure detects compiler linking that's missing the expected hardening `LDFLAGS`. It doesn't matter in this case, for tests, but we may as well follow standard C norms, and respect `LDFLAGS` in the C test suite.