### PR TITLE
The final argument to mont_select() is a size_t

### DIFF
--- a/src/test/test_mont.c
+++ b/src/test/test_mont.c
@@ -5,7 +5,7 @@
 int ge(const uint64_t *x, const uint64_t *y, size_t nw);
 unsigned sub(uint64_t *out, const uint64_t *a, const uint64_t *b, size_t nw);
 void rsquare(uint64_t *r2, uint64_t *n, size_t nw);
-int mont_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, unsigned words);
+int mont_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, size_t words);
 
 void test_ge(void)
 {


### PR DESCRIPTION
Picked up in Ubuntu:
```
cc -g -O2 -ffile-prefix-map=/<<BUILDDIR>>/pycryptodome-3.11.0+dfsg1=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -O3 -g -fstrict-aliasing -Wall -Werror -msse2 -Wdate-time -D_FORTIFY_SOURCE=2 -I.. -DPYCRYPTO_LITTLE_ENDIAN -DHAVE_POSIX_MEMALIGN -DHAVE_STDINT_H -DSTATIC="" -DHAVE_X86INTRIN_H -DUSE_SSE2 -DHAVE_WMMINTRIN_H -DHAVE_TMMINTRIN_H -DHAVE_UINT128  -o build/test_mont test_mont.c build/mont_32.o build/modexp_utils.o build/siphash.o
test_mont.c:8:5: error: type of ‘mont_select’ does not match original declaration [-Werror=lto-type-mismatch]
    8 | int mont_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, unsigned words);
      |     ^
../mont.c:260:22: note: type mismatch in parameter 5
  260 | STATIC FUNC_SSE2 int mont_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, size_t words)
      |                      ^
../mont.c:260:22: note: type ‘size_t’ should match type ‘unsigned int’
../mont.c:260:22: note: ‘mont_select’ was previously declared here
../mont.c:260:22: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used`
```