### PR TITLE
Protect x64 intrinsics with _M_X64 flag

### DIFF
--- a/src/multiply.h
+++ b/src/multiply.h
@@ -15,7 +15,7 @@
     oh = (uint64_t)(pr >> 64);  \
     } while (0)
 
-#elif defined(_MSC_VER) && defined(_WIN64)
+#elif defined(_MSC_VER) && defined(_M_X64)
 
 #include <windows.h>
 #define DP_MULT(a,b,ol,oh) do { ol = UnsignedMultiply128(a,b,&oh); } while (0)

--- a/src/multiply.h
+++ b/src/multiply.h
@@ -15,10 +15,16 @@
     oh = (uint64_t)(pr >> 64);  \
     } while (0)
 
-#elif defined(_MSC_VER) && defined(_M_X64)
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(__x86_64__))
 
 #include <windows.h>
 #define DP_MULT(a,b,ol,oh) do { ol = UnsignedMultiply128(a,b,&oh); } while (0)
+
+#elif defined(_MSC_VER) && defined(_M_ARM64)
+
+#include <intrin.h>
+#pragma intrinsic(__umulh)
+#define DP_MULT(a,b,ol,oh) do { oh = __umulh(a, b); ol = a * b; } while (0)
 
 #else
 

--- a/src/multiply_64.c
+++ b/src/multiply_64.c
@@ -38,7 +38,7 @@
 /**
  * Add a 64-bit value x to y/sum_mid/sum_hi
  */
-#if defined(_M_X64) && (_MSC_VER>=1900)
+#if (_MSC_VER>=1900) && (defined(_M_X64) || defined(__x86_64__))
 
 #include <intrin.h>
 #define ADD192(y, x) do {           \

--- a/src/multiply_64.c
+++ b/src/multiply_64.c
@@ -38,7 +38,7 @@
 /**
  * Add a 64-bit value x to y/sum_mid/sum_hi
  */
-#if defined(_WIN64) && (_MSC_VER>=1900)
+#if defined(_M_X64) && (_MSC_VER>=1900)
 
 #include <intrin.h>
 #define ADD192(y, x) do {           \


### PR DESCRIPTION
This patch uses `_M_X64` flag to protect code that has intrinsics defined only for the x64 platform.

This will enable the compilation of other 64-bit windows targets like windows on arm64 which have `_WIN64` defined without those specific intrinsics defined.