### PR TITLE
Add more wheels for PyPy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,9 +41,6 @@ jobs:
           - python-version: pypy-3.7
             cffi: no
             os: ubuntu-latest
-          - python-version: pypy-3.8
-            cffi: no
-            os: ubuntu-latest
     env:
       CFLAGS: "-Wconversion"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,13 @@ jobs:
           - python-version: pypy2
             cffi: no
             os: ubuntu-latest
-          - python-version: pypy3
+          - python-version: pypy-3.6
+            cffi: no
+            os: ubuntu-latest
+          - python-version: pypy-3.7
+            cffi: no
+            os: ubuntu-latest
+          - python-version: pypy-3.8
             cffi: no
             os: ubuntu-latest
     env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
       CIBW_TEST_SKIP: "*"
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-10.15]
+        os: [ubuntu-20.04, windows-latest, macos-10.15]
 
     if: github.actor == 'Legrandin'
 
@@ -38,7 +38,7 @@ jobs:
         if: runner.os != 'Windows'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp27-* cp35-* pp27-* pp36-*"
+          CIBW_BUILD: "cp27-* cp35-* pp27-* pp36-* pp37-* pp38-*"
 
       - name: Build a 64-bit wheel (Windows)
         if: runner.os == 'Windows'
@@ -73,8 +73,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-10.15]
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6']
+        os: [ubuntu-20.04, windows-latest, macos-10.15]
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
         exclude:
           - {os: "windows-latest", python-version: "pypy-2.7"}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
         if: runner.os != 'Windows'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp27-* cp35-* pp27-* pp36-* pp37-* pp38-*"
+          CIBW_BUILD: "cp27-* cp35-* pp27-* pp36-* pp37-*"
 
       - name: Build a 64-bit wheel (Windows)
         if: runner.os == 'Windows'
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-10.15]
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7']
         exclude:
           - {os: "windows-latest", python-version: "pypy-2.7"}
 


### PR DESCRIPTION
PyPy now considers itself stable up to 3.8, and I was able to run the "Integration test" and "Build wheel" steps succesfully for these newer PyPy releases.