### PR TITLE
getPrime: select candidates randomly

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -150,12 +150,10 @@ def getPrime(N, randfunc=None):
     if N < 2:
         raise ValueError("N must be larger than 1")
 
-    number = getRandomNBitInteger(N, randfunc) | 1
-    while (not isPrime(number, randfunc=randfunc)):
-        number = number + 2
-        if number >= 1 << N:
-            number = (1 << N - 1) | 1
-    return number
+    while True:
+        number = getRandomNBitInteger(N, randfunc) | 1
+        if isPrime(number, randfunc=randfunc):
+            return number
 
 
 def _rabinMillerTest(n, rounds, randfunc=None):


### PR DESCRIPTION
Since prime numbers aren't spaced evenly, looping with `+ 2` introduces biases. The slight bias probably doesn't matter in the real world especially with larger numbers, but this pull request removes the bias.

https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test#Generation_of_probable_primes