### PR TITLE
Change RSA from public key on version 3.3.1 as it has several syntax errors now. 

### DIFF
--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -134,7 +134,7 @@ class RsaKey(object):
         if not self.has_private():
             raise TypeError("This is not a private key")
 
-        e, d, n, p, q, u = [self._key[comp] for comp in 'e', 'd', 'n', 'p', 'q', 'u']
+        e, d, n, p, q, u = [self._key[comp] for comp in ('e', 'd', 'n', 'p', 'q', 'u')]
 
         # Blinded RSA decryption (to prevent timing attacks):
         # Step 1: Generate random secret blinding factor r, such that 0 < r < n-1
@@ -160,7 +160,7 @@ class RsaKey(object):
         return 'd' in self._key
 
     def publickey(self):
-        return RsaKey(dict([(k, self._key[k]) for k in 'n', 'e']))
+        return RsaKey(dict([(k, self._key[k]) for k in ('n', 'e')]))
 
     def __eq__(self, other):
         return self._key == other._key
@@ -263,7 +263,7 @@ class RsaKey(object):
             randfunc = Random.get_random_bytes
 
         if format=='OpenSSH':
-               eb, nb = [self._key[comp].to_bytes() for comp in 'e', 'n']
+               eb, nb = [self._key[comp].to_bytes() for comp in ('e', 'n')]
                if bord(eb[0]) & 0x80: eb=bchr(0x00)+eb
                if bord(nb[0]) & 0x80: nb=bchr(0x00)+nb
                keyparts = [ b('ssh-rsa'), eb, nb ]
@@ -391,8 +391,8 @@ def generate(bits, randfunc=None, e=65537):
 
     u = p.inverse(q)
 
-    key_dict = dict(zip(('n', 'e', 'd', 'p', 'q', 'u'),
-                        (n, e, d, p, q, u)))
+    key_dict = dict(list(zip(('n', 'e', 'd', 'p', 'q', 'u'),
+                        (n, e, d, p, q, u))))
     return RsaKey(key_dict)
 
 
@@ -432,7 +432,7 @@ def construct(tup, consistency_check=True):
     """
 
     comp_names = 'n', 'e', 'd', 'p', 'q', 'u'
-    key_dict = dict(zip(comp_names, map(Integer, tup)))
+    key_dict = dict(list(zip(comp_names, list(map(Integer, tup)))))
     n, e, d, p, q, u = [key_dict.get(comp) for comp in comp_names]
 
     if d is not None:


### PR DESCRIPTION
Using the same file installed on this computer from previous weeks that didn't have any syntax problems.

Today, for some reason, this version of cryptodome has multiple syntax errors on this file.

I hope this helps you :)