### PR TITLE
Allowing unicode character compatibility for PBKDF2

### DIFF
--- a/lib/Crypto/Protocol/KDF.py
+++ b/lib/Crypto/Protocol/KDF.py
@@ -137,8 +137,9 @@ def PBKDF2(password, salt, dkLen=16, count=1000, prf=None, hmac_hash_module=None
         If you want multiple keys, just break up this string into segments of the desired length.
     """
 
-    password = tobytes(password)
-    salt = tobytes(salt)
+
+    password = tobytes(password, 'unicode-escape')
+    salt = tobytes(salt, 'unicode-escape')
 
     if prf and hmac_hash_module:
         raise ValueError("'prf' and 'hmac_hash_module' are mutually exlusive")
@@ -508,7 +509,7 @@ def bcrypt(password, cost, salt=None):
 
    """
 
-    password = tobytes(password, "utf-8")
+    password = tobytes(password, "unicode-escape")
 
     if password.find(bchr(0)[0]) != -1:
         raise ValueError("The password contains the zero byte")


### PR DESCRIPTION
Changed utf-8 to unicode-escape in the bcrypt function and allowed "password" and "salt" in the PBKDF2 function to be compatible with unicode character encoding.

I did this because the passwords/keys and salts I am generating use unicode characters and while trying to encrypt data (using oCrypt0r) it kept spitting out the following error.
```bash
UnicodeEncodeError: 'latin-1' codec can't encode character '\u12a0' in position 0: ordinal not in range(256)
```

It was after I decided to take a look at the PBKDF2 function in the KDF.py file to see that the `tobytes()` function wasn't using an encoding and that the `bcrypt()` function had a `tobytes()` function with `utf-8` encoding. So I decided to give the `tobytes()` function in `bcrypt()` and the 2 others in `PBKDF2()` the `unicode-escape` encoding and now I no longer get the error above and my data now gets encrypted like it should when I use unicode characters for things.

I am unsure as to what affect this may have but all I know is that it fixed my problem and allowed me to encrypt my data using keys/passwords and salts with unicode characters.

Everything has ran smoothly and just fine so far that I can tell when encrypting my data.