### PR TITLE
Fix AES GCM short tag verifiy

### DIFF
--- a/lib/Crypto/Cipher/_mode_gcm.py
+++ b/lib/Crypto/Cipher/_mode_gcm.py
@@ -495,12 +495,17 @@ class GcmMode(object):
         if self.verify not in self._next:
             raise TypeError("verify() cannot be called"
                             " when encrypting a message")
+
+        mac_len = len(received_mac_tag)
+        if mac_len > 16:
+            raise ValueError("Invaild MAC length")
+
         self._next = [self.verify]
 
         secret = get_random_bytes(16)
 
         mac1 = BLAKE2s.new(digest_bits=160, key=secret,
-                           data=self._compute_mac())
+                           data=self._compute_mac()[:mac_len])
         mac2 = BLAKE2s.new(digest_bits=160, key=secret,
                            data=received_mac_tag)
 


### PR DESCRIPTION
Short tag is widely used and defined in `Appendix C: Requirements and Guidelines for Using Short Tags` in `NIST 800-38D`.

Currently short tag verify returns mismatch as computed MAC is not trimmed to target length.

----
_IMHO BLAKE2s hash of MACs is unnecessary, direct compare is more straight forward._