### PR TITLE
Make EccKey.curve not depend on the alias used when constructing

### DIFF
--- a/lib/Crypto/PublicKey/ECC.py
+++ b/lib/Crypto/PublicKey/ECC.py
@@ -753,7 +753,7 @@ class EccKey(object):
         if curve_name not in _curves:
             raise ValueError("Unsupported curve (%s)" % curve_name)
         self._curve = _curves[curve_name]
-        self.curve = curve_name
+        self.curve = self._curve.desc
 
         count = int(self._d is not None) + int(self._seed is not None)
 

--- a/lib/Crypto/SelfTest/PublicKey/test_ECC_NIST.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_ECC_NIST.py
@@ -913,6 +913,12 @@ class TestEccKey_P192(unittest.TestCase):
 
         self.assertNotEqual(public_key, private_key)
 
+    def test_name_consistency(self):
+        key = ECC.generate(curve='p192')
+        self.assertIn("curve='NIST P-192'", repr(key))
+        self.assertEqual(key.curve, 'NIST P-192')
+        self.assertEqual(key.public_key().curve, 'NIST P-192')
+
 
 class TestEccKey_P224(unittest.TestCase):
 
@@ -973,6 +979,12 @@ class TestEccKey_P224(unittest.TestCase):
         self.assertNotEqual(public_key, public_key3)
 
         self.assertNotEqual(public_key, private_key)
+
+    def test_name_consistency(self):
+        key = ECC.generate(curve='p224')
+        self.assertIn("curve='NIST P-224'", repr(key))
+        self.assertEqual(key.curve, 'NIST P-224')
+        self.assertEqual(key.public_key().curve, 'NIST P-224')
 
 
 class TestEccKey_P256(unittest.TestCase):
@@ -1036,6 +1048,12 @@ class TestEccKey_P256(unittest.TestCase):
         self.assertNotEqual(public_key, public_key3)
 
         self.assertNotEqual(public_key, private_key)
+
+    def test_name_consistency(self):
+        key = ECC.generate(curve='p256')
+        self.assertIn("curve='NIST P-256'", repr(key))
+        self.assertEqual(key.curve, 'NIST P-256')
+        self.assertEqual(key.public_key().curve, 'NIST P-256')
 
 
 class TestEccKey_P384(unittest.TestCase):
@@ -1102,6 +1120,12 @@ class TestEccKey_P384(unittest.TestCase):
 
         self.assertNotEqual(public_key, private_key)
 
+    def test_name_consistency(self):
+        key = ECC.generate(curve='p384')
+        self.assertIn("curve='NIST P-384'", repr(key))
+        self.assertEqual(key.curve, 'NIST P-384')
+        self.assertEqual(key.public_key().curve, 'NIST P-384')
+
 
 class TestEccKey_P521(unittest.TestCase):
 
@@ -1166,6 +1190,12 @@ class TestEccKey_P521(unittest.TestCase):
         self.assertNotEqual(public_key, public_key3)
 
         self.assertNotEqual(public_key, private_key)
+
+    def test_name_consistency(self):
+        key = ECC.generate(curve='p521')
+        self.assertIn("curve='NIST P-521'", repr(key))
+        self.assertEqual(key.curve, 'NIST P-521')
+        self.assertEqual(key.public_key().curve, 'NIST P-521')
 
 
 class TestEccModule_P192(unittest.TestCase):


### PR DESCRIPTION
Fixes #658