### PR TITLE
Update examples.rst to close file descriptors after use

### DIFF
--- a/Doc/src/examples.rst
+++ b/Doc/src/examples.rst
@@ -33,6 +33,7 @@ Note that the code generates a ``ValueError`` exception when tampering is detect
 
     file_in = open("encrypted.bin", "rb")
     nonce, tag, ciphertext = [ file_in.read(x) for x in (16, 16, -1) ]
+    file_in.close()
     
     # let's assume that the key is somehow available again
     cipher = AES.new(key, AES.MODE_EAX, nonce)
@@ -141,6 +142,7 @@ first, and with that the rest of the file:
 
     enc_session_key, nonce, tag, ciphertext = \
        [ file_in.read(x) for x in (private_key.size_in_bytes(), 16, 16, -1) ]
+    file_in.close()
 
     # Decrypt the session key with the private RSA key
     cipher_rsa = PKCS1_OAEP.new(private_key)


### PR DESCRIPTION
The examples leave dangling file descriptors for `file_in`.  This PR updates them to close them correctly, as is done for `file_out`.

Alternatively, consider using a context manager.

```
with open("encrypted.bin", "rb") as in_file:
    nonce, tag, ciphertext = [in_file.read(x) for x in (16, 16, -1)]
```