### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
         cffi: [ yes, no ]
         os: [ ubuntu-latest ]
         include:
@@ -17,7 +17,7 @@ jobs:
           - python-version: 2.7
             cffi: yes
             os: macos-10.15
-          - python-version: "3.10"
+          - python-version: "3.11"
             cffi: yes
             os: macos-10.15
           - python-version: 2.7
@@ -26,26 +26,26 @@ jobs:
           - python-version: 2.7
             cffi: yes
             os: windows-latest
-          - python-version: "3.10"
+          - python-version: "3.11"
             cffi: no
             os: windows-latest
-          - python-version: "3.10"
+          - python-version: "3.11"
             cffi: yes
             os: windows-latest
-          - python-version: pypy2
+          - python-version: pypy2.7
             cffi: no
             os: ubuntu-latest
-          - python-version: pypy3
+          - python-version: pypy3.8
             cffi: no
             os: ubuntu-latest
     env:
       CFLAGS: "-Wconversion"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -78,11 +78,11 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install dependencies
       run: |
         pip install mypy pycryptodome-test-vectors
@@ -93,7 +93,7 @@ jobs:
   test_c:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         cd src/test
@@ -102,7 +102,7 @@ jobs:
   test_c_i386:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -115,7 +115,7 @@ jobs:
   test_c_sse2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test
       run: |
         cd src/test

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Build source package (.tar.gz)
         run: python setup.py sdist
@@ -83,7 +83,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
           path: wheels/
@@ -144,7 +144,7 @@ jobs:
             echo "CIBW_ARCHS=AMD64" >> $env:GITHUB_ENV
           }
 
-      - uses: pypa/cibuildwheel@v1.12.0
+      - uses: pypa/cibuildwheel@v2.11.2
         name: Build wheels
         env:
           CIBW_BUILD: "cp27-* pp27-*"

--- a/setup.py
+++ b/setup.py
@@ -525,6 +525,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     license="BSD, Public Domain",
     packages=packages,


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)