### PR TITLE
Improve wording for EdDSA signing options

### DIFF
--- a/Doc/src/signature/eddsa.rst
+++ b/Doc/src/signature/eddsa.rst
@@ -9,7 +9,7 @@ as two variants:
 * *PureEdDSA*, where the message is signed directly.
 * *HashEdDSA*, where the message is first hashed, and only the resulting digest is signed.
   This should only be used by streaming applications because it avoids double passess
-  on messages.
+  on messages, at the cost of reduced collision resistance.
 
 This module supports signatures for both variants (*PureEdDSA* and *HashEdDSA*),
 on the Ed25519 curve (with a 128-bit security level), and


### PR DESCRIPTION
The current wording implies that `HashEdDSA` should be avoided if you're not implementing a streaming application (i.e. "_only_ streaming applications should use `HashEdDSA`"). But if I understand the [RFC](https://datatracker.ietf.org/doc/html/rfc8032) correctly, neither is preferable over the other; in fact, `HashEdDSA` is the version that's actually implemented in the RFC.

I changed the wording to instead mention the actual intention; i.e. it's not that `HashEdDSA` is particularly nice for streaming applications, but rather that `PureEdDSA` is particularly bad for streaming applications