### PR TITLE
Remove C99 for loop initial declarations.

### DIFF
--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -258,13 +258,14 @@ EXPORT_SYM int ed25519_cmp(const Point *p1, const Point *p2)
 {
     uint32_t tmp[10];
     uint8_t bin1[32], bin2[32];
+    unsigned int i;
     int res = 0;
 
     mul_25519(tmp, p1->X, p2->Z);
     convert_le25p5_to_le8(bin1, tmp);
     mul_25519(tmp, p2->X, p1->Z);
     convert_le25p5_to_le8(bin2, tmp);
-    for (unsigned i=0; i<sizeof bin1; i++) {
+    for (i=0; i<sizeof bin1; i++) {
         res |= bin1[i] != bin2[i];
     }
 
@@ -272,7 +273,7 @@ EXPORT_SYM int ed25519_cmp(const Point *p1, const Point *p2)
     convert_le25p5_to_le8(bin1, tmp);
     mul_25519(tmp, p2->Y, p1->Z);
     convert_le25p5_to_le8(bin2, tmp);
-    for (unsigned i=0; i<sizeof bin1; i++) {
+    for (i=0; i<sizeof bin1; i++) {
         res |= bin1[i] != bin2[i];
     }
 

--- a/src/ed448.c
+++ b/src/ed448.c
@@ -209,10 +209,11 @@ STATIC void ed448_add_internal(PointEd448 *Pout,
 STATIC void cswap(PointEd448 *a, PointEd448 *b, unsigned swap)
 {
     uint64_t mask, e, f, g;
+    unsigned int i;
 
     mask = (uint64_t)(0 - (swap!=0));   /* 0 if swap is 0, all 1s if swap is !=0 */
 
-    for (unsigned i=0; i<7; i++) {
+    for (i=0; i<7; i++) {
         e = mask & (a->x[i] ^ b->x[i]);
         a->x[i] ^= e;
         b->x[i] ^= e;


### PR DESCRIPTION
Declarations inside a for loop (e.g.: "for (unsigned i; ;)" ) are only valid in c99 and above.

This change fixes builds on CentOS/RHEL 7, where the compiler default is not c99, and the OS-provided Python 2 does not have -std=c99 in the cflags.