### PR TITLE
remove sha beng from the Selftest.__main__.py

### DIFF
--- a/lib/Crypto/SelfTest/__main__.py
+++ b/lib/Crypto/SelfTest/__main__.py
@@ -1,6 +1,4 @@
-#! /usr/bin/env python
-#
-#  __main__.py : Stand-along loader for PyCryptodome test suite
+#  __main__.py : Stand-alone loader for PyCryptodome test suite
 #
 # ===================================================================
 # The contents of this file are dedicated to the public domain.  To


### PR DESCRIPTION
This sha beng is not needed for anything and as using bin/env could be potentially insecure, it is better to remove it. This is not needed in order to run the selftest module, it will run anyway even without it.

```
$ head -n 5 /usr/lib64/python2.7/site-packages/Cryptodome/SelfTest/__init__.py # -*- coding: utf-8 -*-
#
#  SelfTest/__init__.py: Self-test for PyCrypto
#
# Written in 2008 by Dwayne C. Litzenberger <dlitz@dlitz.net>

$ python2 -m Cryptodome.SelfTest 2>&1| head -n 5
/usr/lib64/python2.7/site-packages/Cryptodome/SelfTest/Cipher/test_DES3.py:64: UserWarning: Warning: skipping extended tests for TDES ECB (TECBMMT2.rsp)
  {"count": lambda x: int(x)}) or []
/usr/lib64/python2.7/site-packages/Cryptodome/SelfTest/Cipher/test_DES3.py:64: UserWarning: Warning: skipping extended tests for TDES ECB (TECBMMT3.rsp)
  {"count": lambda x: int(x)}) or []
/usr/lib64/python2.7/site-packages/Cryptodome/SelfTest/Cipher/test_GCM.py:787: UserWarning: Warning: skipping extended tests for GCM decrypt
```