### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ max-line-length = 110
 [metadata]
 project_urls =
     Source=https://github.com/Legrandin/pycryptodome/
+    Changelog=https://www.pycryptodome.org/src/changelog
 
 [bdist_wheel]
 py-limited-api = cp35


### PR DESCRIPTION
This changelog link will be visible on the package's PyPI page.

Also Renovate bot uses this link to provide quicker access to the changelog for a dependency update.