### PR TITLE
Add DerSequence.insert()

### DIFF
--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -530,6 +530,10 @@ class DerSequence(DerObject):
                 self._seq.append(item)
                 return self
 
+        def insert(self, index, item):
+                self._seq.insert(index, item)
+                return self
+
         def hasInts(self, only_non_negative=True):
                 """Return the number of items in this sequence that are
                 integers.


### PR DESCRIPTION
Use-case: ease semantic creation of optional fields, such as https://www.rfc-editor.org/rfc/rfc5652#section-6.2.4

Brief illustration:

    def construct_pwri(encrypted_cek, ke_alg, kdf_alg=None):
        recipient = DerSequence([DerInteger(0), ke_alg, DerOctetString(encrypted_cek)])
        if kdf_alg is not None:
            if kdf_alg._tag_octet != 0xa0:
                raise ValueError("keyDerivationAlgorithm is of type [0] IMPLICIT SEQUENCE OPTIONAL")
            recipient.insert(1, kdf_alg)
        return recipient