### PR TITLE
Fix ChaCha20 link

### DIFF
--- a/Doc/src/cipher/chacha20.rst
+++ b/Doc/src/cipher/chacha20.rst
@@ -67,7 +67,7 @@ you need to explicitly generate and pass a 96 bit (12 byte) ``nonce`` parameter 
     Code* (such as :doc:`HMAC <../hash/hmac>`) to authenticate the ciphertext
     (*encrypt-then-mac*). Alternatively, you can use :doc:`ChaCha20_Poly1305 <chacha20_poly1305>`.
 
-.. _ChaCha20: http://http://cr.yp.to/chacha.html
+.. _ChaCha20: https://cr.yp.to/chacha.html
 .. _RFC7539: https://tools.ietf.org/html/rfc7539
 
 .. automodule:: Crypto.Cipher.ChaCha20


### PR DESCRIPTION
Link had double `http://http://` and can be updated to `https`