### PR TITLE
Add DerSequence(…, explicit=…)

### DIFF
--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -480,7 +480,7 @@ class DerSequence(DerObject):
 
         """
 
-        def __init__(self, startSeq=None, implicit=None):
+        def __init__(self, startSeq=None, implicit=None, explicit=None):
                 """Initialize the DER object as a SEQUENCE.
 
                 :Parameters:
@@ -493,7 +493,7 @@ class DerSequence(DerObject):
                     It overrides the universal tag for SEQUENCE (16).
                 """
 
-                DerObject.__init__(self, 0x10, b'', implicit, True)
+                DerObject.__init__(self, 0x10, b'', implicit, True, explicit)
                 if startSeq is None:
                     self._seq = []
                 else:

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -491,6 +491,9 @@ class DerSequence(DerObject):
                   implicit : integer
                     The IMPLICIT tag to use for the encoded object.
                     It overrides the universal tag for SEQUENCE (16).
+
+                  explicit : integer
+                    The EXPLICIT tag to use for the encoded object.
                 """
 
                 DerObject.__init__(self, 0x10, b'', implicit, True, explicit)


### PR DESCRIPTION
With this patch, e.g. `der_encoded = DerSequence([1, 2, DerOctetString(b'goose')], explicit=1).encode()` produces valid output, however, `der_obj = DerSequence().decode(der_encoded)` chokes on them.

<em>However</em>: I don't consider this a regression, as the decoder *already* chokes on implicit tags for sequences, which the constructor already accepts and the encoder already outputs. So this commit doesn't introduce any qualitatively new inconsistencies to the codebase. (Obviously, the decoder should handle both explicit- and implicitly tagged sequences in the future; only this first commit doesn't cover them.)

See-Also: https://github.com/Legrandin/pycryptodome/discussions/736