### PR TITLE
asn1: add common string types

### DIFF
--- a/lib/Crypto/SelfTest/Util/test_asn1.py
+++ b/lib/Crypto/SelfTest/Util/test_asn1.py
@@ -39,6 +39,8 @@ from Crypto.Util.py3compat import *
 from Crypto.Util.asn1 import (DerObject, DerSetOf, DerInteger,
                              DerBitString,
                              DerObjectId, DerNull, DerOctetString,
+                             DerGeneralString, DerIA5String, DerUTF8String,
+                             DerUniversalString, DerPrintableString, DerBMPString,
                              DerSequence, DerBoolean)
 
 class DerObjectTests(unittest.TestCase):
@@ -597,6 +599,206 @@ class DerOctetStringTests(unittest.TestCase):
         der = DerOctetString()
         self.assertRaises(ValueError, der.decode, b('\x04\x01\x01\xff'))
 
+
+class DerGeneralStringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerGeneralString(uchr(127))
+        self.assertEqual(der.encode(), b('\x1b\x04\x00\x00\x00\x7f'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerGeneralString()
+        self.assertEqual(der.encode(), b('\x1b\x00'))
+        # Small payload
+        der = DerGeneralString(uchr(0xFFFFD) + uchr(0x10FFFD))
+        self.assertEqual(der.encode(), b('\x1b\x08\x00\x0f\xff\xfd\x00\x10\xff\xfd'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerGeneralString()
+        der.decode(b('\x1b\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x1b\x08\x00\x0f\xff\xfd\x00\x10\xff\xfd'))
+        self.assertEqual(der.value, uchr(0xFFFFD) + uchr(0x10FFFD))
+
+    def testErrDecode1(self):
+        der = DerGeneralString()
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x1b\x04\xf4\x8f\xbf\xbd'))
+
+
+class DerIA5StringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerIA5String(uchr(127))
+        self.assertEqual(der.encode(), b('\x16\x01\x7f'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerIA5String()
+        self.assertEqual(der.encode(), b('\x16\x00'))
+        # Small payload
+        der = DerIA5String(uchr(0) + uchr(127))
+        self.assertEqual(der.encode(), b('\x16\x02\x00\x7f'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerIA5String()
+        der.decode(b('\x16\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x16\x02\x00\x7f'))
+        self.assertEqual(der.value, uchr(0) + uchr(127))
+
+    def testErrDecode1(self):
+        der = DerIA5String()
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x16\x01\x80'))
+
+
+class DerUTF8StringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerUTF8String(uchr(127))
+        self.assertEqual(der.encode(), b('\x0c\x01\x7f'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerUTF8String()
+        self.assertEqual(der.encode(), b('\x0c\x00'))
+        # Small payload
+        der = DerUTF8String(uchr(0xFFFFD) + uchr(0x10FFFD))
+        self.assertEqual(der.encode(), b('\x0c\x08\xf3\xbf\xbf\xbd\xf4\x8f\xbf\xbd'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerUTF8String()
+        der.decode(b('\x0c\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x0c\x08\xf3\xbf\xbf\xbd\xf4\x8f\xbf\xbd'))
+        self.assertEqual(der.value, uchr(0xFFFFD) + uchr(0x10FFFD))
+
+    def testErrDecode1(self):
+        der = DerUTF8String()
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x0c\x08\x00\x0f\xff\xfd\x00\x10\xff\xfd'))
+
+
+class DerUniversalStringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerUniversalString(uchr(127))
+        self.assertEqual(der.encode(), b('\x1c\x04\x00\x00\x00\x7f'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerUniversalString()
+        self.assertEqual(der.encode(), b('\x1c\x00'))
+        # Small payload
+        der = DerUniversalString(uchr(0xFFFFD) + uchr(0x10FFFD))
+        self.assertEqual(der.encode(), b('\x1c\x08\x00\x0f\xff\xfd\x00\x10\xff\xfd'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerUniversalString()
+        der.decode(b('\x1c\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x1c\x08\x00\x0f\xff\xfd\x00\x10\xff\xfd'))
+        self.assertEqual(der.value, uchr(0xFFFFD) + uchr(0x10FFFD))
+
+    def testErrDecode1(self):
+        der = DerUniversalString()
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x1c\x04\xf4\x8f\xbf\xbd'))
+
+
+class DerPrintableStringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerPrintableString(uchr(122))
+        self.assertEqual(der.encode(), b('\x13\x01\x7a'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerPrintableString()
+        self.assertEqual(der.encode(), b('\x13\x00'))
+        # Small payload
+        der = DerPrintableString(uchr(32) + uchr(122))
+        self.assertEqual(der.encode(), b('\x13\x02\x20\x7a'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerPrintableString()
+        der.decode(b('\x13\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x13\x02\x20\x7a'))
+        self.assertEqual(der.value, uchr(32) + uchr(122))
+
+    def testErrDecode1(self):
+        der = DerPrintableString()
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x13\x01\x80'))
+
+    def testErrDecode2(self):
+        der = DerPrintableString()
+        self.assertRaises(ValueError, der.decode, b('\x13\x01\x40'))
+
+    def testErrEncode1(self):
+        self.assertRaises(ValueError, DerPrintableString, uchr(64))
+
+
+class DerBMPStringTests(unittest.TestCase):
+
+    def testInit1(self):
+        der = DerBMPString(uchr(127))
+        self.assertEqual(der.encode(), b('\x1e\x02\x00\x7f'))
+
+    def testEncode1(self):
+        # Empty string
+        der = DerBMPString()
+        self.assertEqual(der.encode(), b('\x1e\x00'))
+        # Small payload
+        der = DerBMPString(uchr(0xE000) + uchr(0xF8FF))
+        self.assertEqual(der.encode(), b('\x1e\x04\xe0\x00\xf8\xff'))
+
+    ####
+
+    def testDecode1(self):
+        # Empty string
+        der = DerBMPString()
+        der.decode(b('\x1e\x00'))
+        self.assertEqual(der.value, '')
+        # Small payload
+        der.decode(b('\x1e\x04\xe0\x00\xf8\xff'))
+        self.assertEqual(der.value, uchr(0xE000) + uchr(0xF8FF))
+
+    def testErrEncode1(self):
+        self.assertRaises(ValueError, DerBMPString, uchr(0xDC00))
+
+    def testErrDecode1(self):
+        der = DerBMPString()
+        # Simple truncation
+        self.assertRaises(UnicodeDecodeError, der.decode, b('\x1e\x03\xef\xa3\xbf'))
+
+    def testErrDecode2(self):
+        der = DerBMPString()
+        # Surrogate pairs
+        self.assertRaises(ValueError, der.decode, b('\x1e\x08\xdb\xbf\xdf\xfd\xdb\xff\xdf\xfd'))
+
+    def testErrEncode2(self):
+        self.assertRaises(ValueError, DerBMPString, uchr(0xF0000))
+
+
 class DerNullTests(unittest.TestCase):
 
     def testEncode1(self):
@@ -837,6 +1039,12 @@ def get_tests(config={}):
     listTests += list_test_cases(DerIntegerTests)
     listTests += list_test_cases(DerSequenceTests)
     listTests += list_test_cases(DerOctetStringTests)
+    listTests += list_test_cases(DerGeneralStringTests)
+    listTests += list_test_cases(DerIA5StringTests)
+    listTests += list_test_cases(DerUTF8StringTests)
+    listTests += list_test_cases(DerUniversalStringTests)
+    listTests += list_test_cases(DerPrintableStringTests)
+    listTests += list_test_cases(DerBMPStringTests)
     listTests += list_test_cases(DerNullTests)
     listTests += list_test_cases(DerObjectIdTests)
     listTests += list_test_cases(DerBitStringTests)

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -711,7 +711,7 @@ class _DerRestrictedString:
     """
     def __init__(self, value='', *a, **k):
         self._check_string(value)
-        super().__init__(value, *a, **k)
+        super(self.__class__, self).__init__(value, *a, **k)
     def _check_string(self, s):
         for c in self._nonalphabet.findall(s):
             raise ValueError("%s not allowed in %s" % (repr(c), self.__class__.__name__))
@@ -719,7 +719,7 @@ class _DerRestrictedString:
     def _nonalphabet(self):
         return NotImplemented
     def decode(self, *a, **k):
-        res = super().decode(*a, **k)
+        res = super(self.__class__, self).decode(*a, **k)
         self._check_string(self.value)
         return res
 

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -689,8 +689,8 @@ class DerOctetString(DerObject):
         DerObject.__init__(self, 0x04, value, implicit, False)
 
 
-class _DerGeneralString(DerOctetString):
-    _codec = 'utf-32-be'  # should this be an abstractproperty?
+class DerGeneralString(DerOctetString):
+    _codec = 'utf-32-be'
     _asn1id = 0x1b
     def __init__(self, value='', implicit=None, explicit=None):
         DerObject.__init__(self, self._asn1id, str.encode(value, self._codec), implicit, False, explicit)
@@ -701,7 +701,7 @@ class _DerGeneralString(DerOctetString):
         return self
 
 
-class _DerRestrictedString(_DerGeneralString):
+class _DerRestrictedString(DerGeneralString):
     def __init__(self, value='', *a, **k):
         self._check_string(value)
         super().__init__(value, *a, **k)

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -711,7 +711,7 @@ class _DerRestrictedString:
         self._check_string(value)
         super().__init__(value, *a, **k)
     def _check_string(self, s):
-        for c, in self._nonalphabet.findall(s)
+        for c in self._nonalphabet.findall(s):
             raise ValueError("%s not allowed in %s" % (repr(c), self.__class__.__name__))
     @abstractproperty
     def _nonalphabet(self):
@@ -738,6 +738,7 @@ class DerPrintableString(DerIA5String, _DerRestrictedString):
 
 
 class DerBMPString(DerGeneralString, _DerRestrictedString):
+    _codec = 'utf-16-be'
     _asn1id = 0x1e
     _nonalphabet = re.compile(r"(?s:(?![%s-%s]).)" % (unichr(0x0000), unichr(0xffff)))
 

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -711,17 +711,17 @@ class _DerRestrictedString:
     # TODO raise ValueError if any(c not in self._alphabet ...)
 
 
-class DerIA5String(_DerGeneralString):
+class DerIA5String(DerGeneralString):
     _codec = 'ascii'
     _asn1id = 0x16
 
 
-class DerUTF8String(_DerGeneralString):
+class DerUTF8String(DerGeneralString):
     _codec = 'utf-8'
     _asn1id = 0x0c
 
 
-class DerUniversalString(_DerGeneralString):
+class DerUniversalString(DerGeneralString):
     _asn1id = 0x1c
 
 

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -701,7 +701,7 @@ class DerGeneralString(DerOctetString):
         return self
 
 
-class _DerRestrictedString(DerGeneralString):
+class _DerRestrictedString:
     def __init__(self, value='', *a, **k):
         self._check_string(value)
         super().__init__(value, *a, **k)

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -23,7 +23,7 @@
 import struct
 import re
 
-from Crypto.Util.py3compat import byte_string, bchr, bord, abstractproperty, unichr
+from Crypto.Util.py3compat import byte_string, bchr, bord, abstractproperty, uchr
 
 from Crypto.Util.number import long_to_bytes, bytes_to_long
 
@@ -740,7 +740,7 @@ class DerPrintableString(DerIA5String, _DerRestrictedString):
 class DerBMPString(DerGeneralString, _DerRestrictedString):
     _codec = 'utf-16-be'
     _asn1id = 0x1e
-    _nonalphabet = re.compile(r"(?s:(?![%s-%s]).)" % (unichr(0x0000), unichr(0xffff)))
+    _nonalphabet = re.compile(r"(?s:(?![%s-%s]).)" % (uchr(0x0000), uchr(0xffff)))
 
 
 class DerNull(DerObject):

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -737,7 +737,7 @@ class DerPrintableString(DerIA5String, _DerRestrictedString):
     _nonalphabet = re.compile(r"(?s:(?![ '()+,\-./0-9:=?a-zA-Z]).)")
 
 
-class DerBMPString(DerGeneralString, _DerRestrictedString):
+class DerBMPString(DerUniversalString, _DerRestrictedString):
     _codec = 'utf-16-be'
     _asn1id = 0x1e
     _nonalphabet = re.compile(r"(?s:(?![%s-%s]).)" % (uchr(0x0000), uchr(0xffff)))

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -742,7 +742,7 @@ class DerPrintableString(DerIA5String, _DerRestrictedString):
 class DerBMPString(DerUniversalString, _DerRestrictedString):
     _codec = 'utf-16-be'
     _asn1id = 0x1e
-    _nonalphabet = re.compile(r"(?s:(?![%s-%s]).)" % (uchr(0x0000), uchr(0xffff)))
+    _nonalphabet = re.compile(r"(?s)(?![%s-%s])." % (uchr(0x0000), uchr(0xffff)))
 
 
 class DerNull(DerObject):

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -699,7 +699,7 @@ class DerGeneralString(DerOctetString):
         DerObject.__init__(self, self._asn1id, str.encode(value, self._codec), implicit, False, explicit)
         self.value = value
     def decode(self, der_encoded, strict=False):
-        DerObject.decode(self, der_encoded, strict)
+        super(self.__class__, self).decode(der_encoded, strict)
         self.value = bytes.decode(self.payload, self._codec)
         return self
 

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -736,7 +736,7 @@ class DerUniversalString(DerGeneralString):
 
 class DerPrintableString(DerIA5String, _DerRestrictedString):
     _asn1id = 0x13
-    _nonalphabet = re.compile(r"(?s:(?![ '()+,\-./0-9:=?a-zA-Z]).)")
+    _nonalphabet = re.compile(r"(?s)(?![ '()+,\-./0-9:=?a-zA-Z]).")
 
 
 class DerBMPString(DerUniversalString, _DerRestrictedString):

--- a/lib/Crypto/Util/asn1.py
+++ b/lib/Crypto/Util/asn1.py
@@ -28,7 +28,9 @@ from Crypto.Util.py3compat import byte_string, bchr, bord, abstractproperty, uch
 from Crypto.Util.number import long_to_bytes, bytes_to_long
 
 __all__ = ['DerObject', 'DerInteger', 'DerBoolean', 'DerOctetString',
-           'DerNull', 'DerSequence', 'DerObjectId', 'DerBitString', 'DerSetOf']
+           'DerNull', 'DerSequence', 'DerObjectId', 'DerBitString', 'DerSetOf',
+           'DerGeneralString', 'DerIA5String', 'DerUTF8String',
+           'DerUniversalString', 'DerPrintableString', 'DerBMPString']
 
 # Useful references:
 # - https://luca.ntop.org/Teaching/Appunti/asn1.html

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -92,7 +92,7 @@ if sys.version_info[0] == 2:
 
     from sys import maxint
 
-    uchr = unichr
+    from builtins import unichr
 
     iter_range = xrange
 
@@ -144,8 +144,8 @@ else:
     from io import BytesIO
     from io import StringIO
     from sys import maxsize as maxint
+    from builtins import chr as unichr
 
-    uchr = chr
     iter_range = range
 
     def is_native_int(x):

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -92,7 +92,7 @@ if sys.version_info[0] == 2:
 
     from sys import maxint
 
-    from builtins import unichr
+    uchr = unichr
 
     iter_range = xrange
 
@@ -142,8 +142,8 @@ else:
     from io import BytesIO
     from io import StringIO
     from sys import maxsize as maxint
-    from builtins import chr as unichr
 
+    uchr = chr
     iter_range = range
 
     def is_native_int(x):

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -92,7 +92,7 @@ if sys.version_info[0] == 2:
 
     from sys import maxint
 
-    from builtins import unichr
+    uchr = unichr
 
     iter_range = xrange
 

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -109,6 +109,8 @@ if sys.version_info[0] == 2:
 
     ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
 
+    from abc import abstractproperty
+
     FileNotFoundError = IOError
 
 else:
@@ -159,12 +161,9 @@ else:
 
     from abc import ABC
 
-    if sys.version_info < (3, 3):
-        from abc import abstractproperty
-    else:
-        from abc import abstractmethod
-        def abstractproperty(f):
-            return property(abstractmethod(f))
+    from abc import abstractmethod
+    def abstractproperty(f):
+        return property(abstractmethod(f))
 
     FileNotFoundError = FileNotFoundError
 

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -92,6 +92,8 @@ if sys.version_info[0] == 2:
 
     from sys import maxint
 
+    from builtins import unichr
+
     iter_range = xrange
 
     def is_native_int(x):
@@ -140,6 +142,7 @@ else:
     from io import BytesIO
     from io import StringIO
     from sys import maxsize as maxint
+    from builtins import chr as unichr
 
     iter_range = range
 
@@ -155,6 +158,13 @@ else:
                 isinstance(x, memoryview)
 
     from abc import ABC
+
+    if sys.version_info < (3, 3):
+        from abc import abstractproperty
+    else:
+        from abc import abstractmethod
+        def abstractproperty(f):
+            return property(abstractmethod(f))
 
     FileNotFoundError = FileNotFoundError
 

--- a/lib/Crypto/Util/py3compat.py
+++ b/lib/Crypto/Util/py3compat.py
@@ -144,7 +144,7 @@ else:
     from io import BytesIO
     from io import StringIO
     from sys import maxsize as maxint
-    from builtins import chr as unichr
+    from builtins import chr as uchr
 
     iter_range = range
 


### PR DESCRIPTION
Is this something you'd be interested in merging?

I believe it'll be needed for some interactions down the road with CMS (e.g. every asymmetric recipient type except for `SubjectPublicKeyInfo`), but I'm not sure how well this aligns with your vision for the codebase as it currently stands.