### PR TITLE
Remove unused import in GCM decrypt code example.

### DIFF
--- a/Doc/src/cipher/modern.rst
+++ b/Doc/src/cipher/modern.rst
@@ -291,7 +291,6 @@ Example (decryption)::
     >>> import json
     >>> from base64 import b64decode
     >>> from Crypto.Cipher import AES
-    >>> from Crypto.Util.Padding import unpad
     >>>
     >>> # We assume that the key was securely shared beforehand
     >>> try:


### PR DESCRIPTION
While reading the API docs at https://www.pycryptodome.org/src/cipher/modern#gcm-mode for AES in GCM mode, I noticed an import statement for unpad that wasn't being used.

Patch to remove that import, a minor tweak to be sure.

`make html` appears to build the docs as expected.

Hope this helps!