### PR TITLE
Allow tuple and list arguments in TupleHash

### DIFF
--- a/Doc/src/hash/tuplehash128.rst
+++ b/Doc/src/hash/tuplehash128.rst
@@ -35,6 +35,15 @@ This is an example showing how to generate a TupleHash128 for the 3 bytes string
     >>> print(hd.hexdigest())
     4c095be894c21cfe7076a7d0fe3f70ed
 
+A list or a tuple of byte strings can be submitted as well via the ``update()`` method,
+while keeping the domain separation between each items. This is an example::
+    >>> from Crypto.Hash import TupleHash128
+    >>>
+    >>> hd = TupleHash128.new(digest_bytes=16)
+    >>> hd.update((b'deposit', b'100', b'joe'))
+    >>> print(hd.hexdigest())
+    4c095be894c21cfe7076a7d0fe3f70ed
+
 Any or even all the byte strings in the sequence can be empty.
 An empty byte string is significant: calling ``update(b'')`` will still contribute to and modify the final digest.
 

--- a/lib/Crypto/Hash/TupleHash128.py
+++ b/lib/Crypto/Hash/TupleHash128.py
@@ -48,19 +48,26 @@ class TupleHash(object):
         self._digest = None
 
     def update(self, data):
-        """Authenticate the next byte string in the tuple.
+        """Authenticate the next byte string in the tuple or a tuple directly.
 
         Args:
-            data (bytes/bytearray/memoryview): The next byte string.
+            data (bytes/bytearray/memoryview/tuple/list): The next byte string or a list/tuple of byte strings.
         """
 
         if self._digest is not None:
             raise TypeError("You cannot call 'update' after 'digest' or 'hexdigest'")
 
-        if not is_bytes(data):
-            raise TypeError("You can only call 'update' on bytes")
+        # Test if data is a tuple or list
+        if type(data) == list or type(data) == tuple:
+            for b in data:
+                if not is_bytes(b):
+                    raise TypeError("You can only call 'update' on a tuple of bytes")
 
-        self._cshake.update(_encode_str(tobytes(data)))
+                self._cshake.update(_encode_str(tobytes(b)))
+        elif not is_bytes(data):
+            raise TypeError("You can only call 'update' on bytes" )
+        else:
+            self._cshake.update(_encode_str(tobytes(data)))
 
         return self
 

--- a/lib/Crypto/SelfTest/Hash/test_TupleHash.py
+++ b/lib/Crypto/SelfTest/Hash/test_TupleHash.py
@@ -263,12 +263,18 @@ class NISTExampleTestVectors(unittest.TestCase):
 
     def runTest(self):
 
+        # Test with tuple
+        data, custom, digest, text, module = self.test_data.pop()
+        hd = module.new(custom=custom, digest_bytes=len(digest))
+        hd.update(data)
+        self.assertEqual(hd.digest(), digest, msg=text)
+
+        # Test with bytes
         for data, custom, digest, text, module in self.test_data:
             hd = module.new(custom=custom, digest_bytes=len(digest))
             for string in data:
                 hd.update(string)
             self.assertEqual(hd.digest(), digest, msg=text)
-
 
 def get_tests(config={}):
     tests = []


### PR DESCRIPTION
Allowing to input list or tuple as arguments to TupleHash algorithms. Since the purpose of TupleHash is to hash with domain separation this is natural to allow tuple and list arguments and simplify the usage.