### PR TITLE
Remove Python 2.7 from CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,34 +7,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11" ]
         cffi: [ yes, no ]
         os: [ ubuntu-20.04 ]
         include:
-          - python-version: 2.7
-            cffi: no
-            os: macos-12
-          - python-version: 2.7
-            cffi: yes
-            os: macos-12
           - python-version: "3.11"
             cffi: yes
             os: macos-12
-          - python-version: 2.7
-            cffi: no
-            os: windows-latest
-          - python-version: 2.7
-            cffi: yes
-            os: windows-latest
           - python-version: "3.11"
             cffi: no
             os: windows-latest
           - python-version: "3.11"
             cffi: yes
             os: windows-latest
-          - python-version: pypy2.7
-            cffi: no
-            os: ubuntu-latest
           - python-version: pypy3.8
             cffi: no
             os: ubuntu-latest
@@ -55,17 +40,6 @@ jobs:
     - name: Install CFFI
       if: matrix.cffi == 'yes'
       run: pip install cffi
-
-    - name: Install MSVC
-      if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-      uses: ilammy/msvc-dev-cmd@v1
-
-    - name: Prepare environmental variables
-      if: matrix.os == 'windows-latest' && matrix.python-version == '2.7'
-      shell: bash
-      run: |
-        echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
-        echo "MSSdk=1" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Python 2.7 is not supported in python-setup since June 19th 2023: https://github.com/actions/setup-python/issues/672.