### PR TITLE
check for __cpuidex in intrin.h

### DIFF
--- a/compiler_opt.py
+++ b/compiler_opt.py
@@ -138,8 +138,8 @@ def compiler_has_intrin_h():
     #include <intrin.h>
     int main(void)
     {
-        int a, b[4];
-        __cpuid(b, a);
+        int a, b[4], c;
+        __cpuidex(b, a, c);
         return 0;
     }
     """


### PR DESCRIPTION
This is what is actually used, rather than __cpuid.  Due to what I assume is a bug in mingw-w64, __cpuid is prototyped on ARM64, even though there is no definition, which caused this check to succeed and compilation to later fail due to missing __cpuidex (it would have failed at link time if __cpuid was used instead)