### PR TITLE
Build PyPy wheels only for versions 3.9 and 3.10, and not for 3.8 anymore

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
           - python-version: pypy2.7
             cffi: no
             os: ubuntu-latest
-          - python-version: pypy3.8
+          - python-version: pypy3.9
             cffi: no
             os: ubuntu-latest
     env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,12 +42,12 @@ jobs:
           echo 'CIBW_ARCHS=x86_64 universal2' >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
-      - uses: pypa/cibuildwheel@v2.11.2
+      - uses: pypa/cibuildwheel@v2.14.1
         name: Build wheels
         env:
           # cibuildwheel will build wheel once and test it for each CPython version
-          # and for PyPy > 3.7.
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp38-* pp39-*"
+          # and for PyPy > 3.8.
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp39-* pp310-*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
           CIBW_MANYLINUX_I686_IMAGE: "manylinux2014"
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: "manylinux2014"


### PR DESCRIPTION
https://www.pypy.org/download.html