### PR TITLE
The final argument to mod_select() is a size_t

### DIFF
--- a/src/test/test_mont.c
+++ b/src/test/test_mont.c
@@ -5,7 +5,7 @@
 int ge(const uint64_t *x, const uint64_t *y, size_t nw);
 unsigned sub(uint64_t *out, const uint64_t *a, const uint64_t *b, size_t nw);
 void rsquare(uint64_t *r2, uint64_t *n, size_t nw);
-int mod_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, unsigned words);
+int mod_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, size_t words);
 
 void test_ge(void)
 {


### PR DESCRIPTION
Hi, I have updated this patch in Debian, because the change that was previously merged has been reverted back. The function name has changed, but the type mismatch issue is still there. Below contains the current patch in Debian:

```
--- a/src/test/test_mont.c
+++ b/src/test/test_mont.c
@@ -5,7 +5,7 @@
 int ge(const uint64_t *x, const uint64_t *y, size_t nw);
 unsigned sub(uint64_t *out, const uint64_t *a, const uint64_t *b, size_t nw);
 void rsquare(uint64_t *r2, uint64_t *n, size_t nw);
-int mod_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, unsigned words);
+int mod_select(uint64_t *out, const uint64_t *a, const uint64_t *b, unsigned cond, size_t words);
 
 void test_ge(void)
 {
```

The revision occurred during this [commit](https://github.com/Legrandin/pycryptodome/commit/764c1e81b940596d10cc22e00ca99cc628e504a6), and it was originally fixed during this [pull request](https://github.com/Legrandin/pycryptodome/pull/576).