### PR TITLE
Change tag variable name in code example to reduce confusion

### DIFF
--- a/Doc/src/hash/kmac128.rst
+++ b/Doc/src/hash/kmac128.rst
@@ -22,13 +22,13 @@ And this is an example showing how to validate the KMAC128 tag::
     >>> from Crypto.Hash import KMAC128
     >>>
     >>> # We have received a message 'msg' together
-    >>> # with its MAC 'mac'
+    >>> # with its MAC 'mac_tag'
     >>>
     >>> secret = b'Sixteen byte key'
     >>> mac = KMAC128.new(key=secret, mac_len=16)
     >>> mac.update(msg)
     >>> try:
-    >>>   mac.verify(mac)
+    >>>   mac.verify(mac_tag)
     >>>   print("The message '%s' is authentic" % msg)
     >>> except ValueError:
     >>>   print("The message or the key is wrong")

--- a/Doc/src/hash/kmac256.rst
+++ b/Doc/src/hash/kmac256.rst
@@ -22,13 +22,13 @@ And this is an example showing how to validate the KMAC256 tag::
     >>> from Crypto.Hash import KMAC256
     >>>
     >>> # We have received a message 'msg' together
-    >>> # with its MAC 'mac'
+    >>> # with its MAC 'mac_tag'
     >>>
     >>> secret = b'Protect this thirty-two byte key'
     >>> mac = KMAC256.new(key=secret, mac_len=16)
     >>> mac.update(msg)
     >>> try:
-    >>>   mac.verify(mac)
+    >>>   mac.verify(mac_tag)
     >>>   print("The message '%s' is authentic" % msg)
     >>> except ValueError:
     >>>   print("The message or the key is wrong")


### PR DESCRIPTION
While trying the second code example (validate a MAC tag) at https://www.pycryptodome.org/src/hash/kmac256, I noticed that the MAC instance variable name is `mac` and the authentication tag variable name is `mac`, which makes the `mac.verify(mac)` call somewhat confusing.

Won't trip up anyone who is paying attention to be sure, but submitting a patch to change the tag variable name to `mac_tag`, which should clear up any potential confusion. The proposed change follows the precedent in the corresponding Poly1305 code example at https://www.pycryptodome.org/src/hash/poly1305 (which calls the tag variable `mac_tag_hex`).

`make html` appears to build the docs as expected.

Hope this helps!