### PR TITLE
Expand unit tests for TupleHash.update()

### DIFF
--- a/lib/Crypto/Hash/TupleHash128.py
+++ b/lib/Crypto/Hash/TupleHash128.py
@@ -58,9 +58,6 @@ class TupleHash(object):
         if self._digest is not None:
             raise TypeError("You cannot call 'update' after 'digest' or 'hexdigest'")
 
-        if data is None:
-            raise ValueError("No data to hash")
-
         for item in data:
             if not is_bytes(item):
                 raise TypeError("You can only call 'update' on bytes" )

--- a/lib/Crypto/Hash/TupleHash128.py
+++ b/lib/Crypto/Hash/TupleHash128.py
@@ -59,7 +59,7 @@ class TupleHash(object):
             raise TypeError("You cannot call 'update' after 'digest' or 'hexdigest'")
 
         if data is None:
-            raise ValueErorr("No data to hash")
+            raise ValueError("No data to hash")
 
         for item in data:
             if not is_bytes(item):

--- a/lib/Crypto/SelfTest/Hash/test_TupleHash.py
+++ b/lib/Crypto/SelfTest/Hash/test_TupleHash.py
@@ -62,8 +62,12 @@ class TupleHashTest(unittest.TestCase):
         h.update(b'STRING1')
         h.update(b'STRING2')
         mac2 = h.digest()
-
         self.assertNotEqual(mac1, mac2)
+
+        h = self.new()
+        h.update(b'STRING1', b'STRING2')
+        mac3 = h.digest()
+        self.assertEqual(mac2, mac3)
 
     def test_update_negative(self):
         h = self.new()

--- a/lib/Crypto/SelfTest/Hash/test_TupleHash.py
+++ b/lib/Crypto/SelfTest/Hash/test_TupleHash.py
@@ -66,8 +66,12 @@ class TupleHashTest(unittest.TestCase):
 
         h = self.new()
         h.update(b'STRING1', b'STRING2')
-        mac3 = h.digest()
-        self.assertEqual(mac2, mac3)
+        self.assertEqual(mac2, h.digest())
+
+        h = self.new()
+        t = b'STRING1', b'STRING2'
+        h.update(*t)
+        self.assertEqual(mac2, h.digest())
 
     def test_update_negative(self):
         h = self.new()

--- a/lib/Crypto/SelfTest/Hash/test_TupleHash.py
+++ b/lib/Crypto/SelfTest/Hash/test_TupleHash.py
@@ -69,6 +69,7 @@ class TupleHashTest(unittest.TestCase):
         h = self.new()
         self.assertRaises(TypeError, h.update, u"string")
         self.assertRaises(TypeError, h.update, None)
+        self.assertRaises(TypeError, h.update, (b'STRING1', b'STRING2'))
 
     def test_digest(self):
         h = self.new()


### PR DESCRIPTION
While documenting issue #767, I noticed a typo (`ValueError` was `ValueErorr`) in `TupleHash.update()`. After fixing typo, I realized that this was dead code (not reachable by calling `update(None)`; likely left over from an earlier version of this function as the existing unit test for `update(None)` expects `TypeError` not `ValueError`.

So, removed the `if data is None` precondition check for `update()` and confirmed unit tests pass.

Also, while I was here, expanded the unit tests to test the happy path for the newly supported ways to pass multiple byte strings as well as a regression test in `test_update_negative()` to catch that `update(tuple)` raises the expected exception.