### PR TITLE
Update DSA docs to use Python 3 print

### DIFF
--- a/Doc/src/signature/dsa.rst
+++ b/Doc/src/signature/dsa.rst
@@ -30,9 +30,9 @@ The receiver can use the matching *public* key to verify authenticity of the rec
         >>> verifier = DSS.new(key, 'fips-186-3')
         >>> try:
         >>>     verifier.verify(h, signature)
-        >>>     print "The message is authentic."
+        >>>     print("The message is authentic.")
         >>> except ValueError:
-        >>>     print "The message is not authentic."
+        >>>     print("The message is not authentic.")
 
 .. __: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
 


### PR DESCRIPTION
Small commit, noticed some old py2 style `print` statements while copying an example from the DSA docs 