### PR TITLE
AES-CCM enforce max length

### DIFF
--- a/lib/Crypto/Cipher/_mode_ccm.py
+++ b/lib/Crypto/Cipher/_mode_ccm.py
@@ -189,9 +189,13 @@ class CcmMode(object):
 
         # Formatting control information and nonce (A.2.1)
         q = 15 - len(self.nonce)  # length of Q, the encoded message length
+        # Limit on plaintext length imposed by choice of nonce (A.1)
+        if self._msg_len >= 2**(8*q):
+            raise OverflowError("Combined plaintext and nonce too long")
         flags = (64 * (self._assoc_len > 0) + 8 * ((self._mac_len - 2) // 2) +
                  (q - 1))
         b_0 = struct.pack("B", flags) + self.nonce + long_to_bytes(self._msg_len, q)
+        assert len(b_0) == 16
 
         # Formatting associated data (A.2.2)
         # Encoded 'a' is concatenated with the associated data 'A'

--- a/lib/Crypto/SelfTest/Cipher/test_CCM.py
+++ b/lib/Crypto/SelfTest/Cipher/test_CCM.py
@@ -241,6 +241,19 @@ class CcmTests(unittest.TestCase):
                          msg_len=DATA_LEN - 1)
         self.assertRaises(ValueError, cipher.decrypt, ct)
 
+    def test_plaintext_too_long_for_nonce(self):
+        nonce = get_tag_random("nonce", 13)
+        # The octet length of the binary representation of the octet length
+        # of the payload.
+        q = 15 - len(nonce)
+
+        # The plaintext must be shorter than this
+        # See Appendix A.1 of NIST SP 800-38C
+        data_len_limit = 2**(8 * q)
+        data = bytearray(data_len_limit)
+        cipher = AES.new(self.key_128, AES.MODE_CCM, nonce=nonce)
+        self.assertRaises(OverflowError, cipher.encrypt_and_digest, data)
+
     def test_message_chunks(self):
         # Validate that both associated data and plaintext/ciphertext
         # can be broken up in chunks of arbitrary length


### PR DESCRIPTION
[NIST Special Publication 800-38C ](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38c.pdf) Appendix 1 states that the maximum length of payload is determined by the value of q (which in turn is related to the length of the nonce).

It seems as if this condition wasn't previously enforced which could lead to the block b0 exceeding 16 bytes.