### PR TITLE
Allow label for SP800_108_Counter to include null bytes

### DIFF
--- a/lib/Crypto/Protocol/KDF.py
+++ b/lib/Crypto/Protocol/KDF.py
@@ -616,9 +616,6 @@ def SP800_108_Counter(master, key_len, prf, num_keys=None, label=b'', context=b'
     if num_keys is None:
         num_keys = 1
 
-    if label.find(b'\x00') != -1:
-        raise ValueError("Null byte found in label")
-
     if context.find(b'\x00') != -1:
         raise ValueError("Null byte found in context")
 

--- a/lib/Crypto/SelfTest/Protocol/test_KDF.py
+++ b/lib/Crypto/SelfTest/Protocol/test_KDF.py
@@ -720,8 +720,10 @@ class SP800_180_Counter_Tests(unittest.TestCase):
         def prf(s, x):
             return HMAC.new(s, x, SHA256).digest()
 
-        self.assertRaises(ValueError, SP800_108_Counter, b'0' * 16, 1, prf,
-                          label=b'A\x00B')
+        try:
+            _ = SP800_108_Counter(b'0' * 16, 1, prf, label=b'A\x00B')
+        except ValueError:
+            self.fail('SP800_108_Counter failed with zero in label')
         self.assertRaises(ValueError, SP800_108_Counter, b'0' * 16, 1, prf,
                           context=b'A\x00B')
 


### PR DESCRIPTION
Null bytes to should allowed in the `label` argument of `SP800_108_Counter()` as this is required in some RFCs such as RFC8009 where this is explicitly stated in [key derivation examples](https://datatracker.ietf.org/doc/html/rfc8009#page-13).

[SP.800-108r1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf) does not give any indication about what the content of the label is expected to be. This is expected to be defined in the protocol specifications:

> *Label* – A string that identifies the purpose for the derived keying material, which is encoded as a bit string. The encoding method for the Label is defined in a larger context, for example, in the protocol that uses a KDF.