### PR TITLE
Update PSS docs for Python 3.

### DIFF
--- a/Doc/src/signature/pkcs1_pss.rst
+++ b/Doc/src/signature/pkcs1_pss.rst
@@ -12,10 +12,9 @@ The following example shows how the sender can use its own *private* key
     >>> from Crypto.Signature import pss
     >>> from Crypto.Hash import SHA256
     >>> from Crypto.PublicKey import RSA
-    >>> from Crypto import Random
     >>>
-    >>> message = 'To be signed'
-    >>> key = RSA.import_key(open('privkey.der').read())
+    >>> message = b'To be signed'
+    >>> key = RSA.import_key(open('privkey.der', 'rb').read())
     >>> h = SHA256.new(message)
     >>> signature = pss.new(key).sign(h)
 


### PR DESCRIPTION
While trying the code example (for signing) at https://www.pycryptodome.org/src/signature/pkcs1_pss, I ran into a few exceptions (in Python 3.10). Figured this may be a good time to update this example.

Patch does the following:
- Update `message` to byte string (otherwise `SHA256.new()` throws an exception).
- Update `RSA.import_key()` to read DER file in binary (otherwise this call throws an exception too; plus, `pss.new()` expects a byte string now).
- Removed an unused import statement for `Crypto.Random`.

`make html` appears to build the docs as expected.

Hope this helps!