### PR TITLE
Update PSS verify signature code example.

### DIFF
--- a/Doc/src/signature/pkcs1_pss.rst
+++ b/Doc/src/signature/pkcs1_pss.rst
@@ -21,14 +21,14 @@ The following example shows how the sender can use its own *private* key
 At the receiver side, the matching *public* RSA key is used to verify
 authenticity of the incoming message::
 
-    >>> key = RSA.import_key(open('pubkey.der').read())
+    >>> key = RSA.import_key(open('pubkey.der', 'rb').read())
     >>> h = SHA256.new(message)
     >>> verifier = pss.new(key)
     >>> try:
     >>>     verifier.verify(h, signature)
-    >>>     print "The signature is authentic."
-    >>> except (ValueError, TypeError):
-    >>>     print "The signature is not authentic."
+    >>>     print("The signature is authentic.")
+    >>> except (ValueError):
+    >>>     print("The signature is not authentic.")
 
 .. __: https://tools.ietf.org/html/rfc8017#section-8.1
 


### PR DESCRIPTION
For completeness sake, update code example for verifying a signature (#783 just updated the signing code example).

Patch does the following:
* Update `RSA.import_key()` to read DER file in binary.
* Remove `TypeError` from except clause.
  * Does not appear that verify() should throw this exception; or that the caller is expected to do anything based on API docs at https://www.pycryptodome.org/src/signature/pkcs1_pss#Crypto.Signature.pss.PSS_SigScheme.verify.
  * Also, checked the unit tests, the "negative" tests are just checking for `ValueError`.
* Update print statements for Python 3.

`make html` appears to build the docs as expected.

Hope this helps!