### PR TITLE
fixing CMakeLists for non-x86 architectures

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,23 +57,26 @@ endif()
 
 # Use processor extensions
 # TODO: add exception if non-x86 platform
-if (MSVC)
+# The test will run only for x86-64 and AMD64 architectures
+if (MSVC AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
     add_compile_definitions(HAVE_INTRIN_H)
     add_compile_definitions(USE_SSE2)
     add_compile_definitions(HAVE_WMMINTRIN_H)
     add_compile_definitions(HAVE_TMMINTRIN_H)
 else()
-    if (SSE)
-	message(STATUS "Using SSE instructions")
+    if (SSE AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+        message(STATUS "Using SSE instructions")
         add_compile_definitions(HAVE_X86INTRIN_H)
-	add_compile_definitions(HAVE_TMMINTRIN_H)
-	add_compile_options(-mssse3 -mpclmul)
+        add_compile_definitions(HAVE_TMMINTRIN_H)
+        add_compile_options(-mssse3 -mpclmul)
     endif()
+
     if (SSE OR AESNI)
-	add_compile_definitions(HAVE_WMMINTRIN_H)
+	    add_compile_definitions(HAVE_WMMINTRIN_H)
     endif()
-    if (AESNI)
-	add_compile_options(-maes)
+
+    if (AESNI AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64" )
+	    add_compile_options(-maes)
     endif()
 endif()
 


### PR DESCRIPTION
As requested in issue #774, I added a condition in the CMakeLists so non-x86 can run the test. As I didn't have non-x86 archi, I hope this work.
Also I the opened issue other errors where reported like this one: 

[ 97%] Building C object CMakeFiles/test_aesni.dir/test_aesni.c.o
[...]/src/test/test_aesni.c:2:10: fatal error: wmmintrin.h: No such file or directory
    2 | #include <wmmintrin.h>
      |          ^~~~~~~~~~~~~

Maybe we should add directive for packages that aren't supported.