### PR TITLE
fix small typo in Crypto.Util.number isPrime returns

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -378,7 +378,7 @@ def isPrime(N, false_positive_prob=1e-6, randfunc=None):
           If omitted, :func:`Crypto.Random.get_random_bytes` is used.
 
     Return:
-        `True` is the input is indeed prime.
+        `True` if the input is indeed prime.
     """
 
     if randfunc is None:


### PR DESCRIPTION
Noticed a typo while reading the documentation for the `isPrime` function that is provided in `Crypto.Util.number`. 

The `returns` section of the function documentation read "`is the input is indeed prime`". The commit in this PR fixes the spelling error to make the sentence grammatically correct by updating it to read "`if the input is indeed prime`". 