### PR TITLE
Clarifying behavior for Crypto.PublicKey.RSA.export_key in docs

### DIFF
--- a/lib/Crypto/PublicKey/RSA.py
+++ b/lib/Crypto/PublicKey/RSA.py
@@ -271,7 +271,8 @@ class RsaKey(object):
             - ``'PEM'``. (default) Text output, according to `RFC1421`_/`RFC1423`_.
             - ``'DER'``. Binary output.
             - ``'OpenSSH'``. Text output, according to the OpenSSH specification.
-              Only suitable for public keys (not private keys).
+              Only suitable for public keys (not private keys). If used with an 
+              RSA private key, will export the corresponding public key instead.
 
             Note that PEM contains a DER structure.
 


### PR DESCRIPTION
The format='OpenSSH' parameter in Crypto.PublicKey.RSA.export_key when used with a **private** key exports the public key instead. The code extracts only the public key parameters and writes them to bytes from what I understand.

The current doc says "Only suitable for public keys", which I think does not convey what could happen if someone were to use a private key anyhow. It does not throw an error either. So I believe it would make sense to document this behavior.