### PR TITLE
disable RTLD_DEEPBIND if PYCRYPTODOME_DISABLE_DEEPBIND is set to empty string

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -195,7 +195,7 @@ New features
 * Added cSHAKE128 and cSHAKE256 (of SHA-3 family). Thanks to Michael Schaffner.
 * GH#558: The flag RTLD_DEEPBIND passed to ``dlopen()`` is not well supported by
   `address sanitizers <https://github.com/google/sanitizers/issues/611>`_.
-  It is now possible to set the environment variable ``PYCRYPTDOME_DISABLE_DEEPBIND``
+  It is now possible to set the environment variable ``PYCRYPTODOME_DISABLE_DEEPBIND``
   to drop that flag and allow security testing.
 
 3.10.4 (25 September 2021)

--- a/lib/Crypto/Util/_raw_api.py
+++ b/lib/Crypto/Util/_raw_api.py
@@ -99,7 +99,7 @@ try:
         @cdecl, the C function declarations.
         """
 
-        if hasattr(ffi, "RTLD_DEEPBIND") and not os.getenv('PYCRYPTODOME_DISABLE_DEEPBIND'):
+        if hasattr(ffi, "RTLD_DEEPBIND") and os.getenv('PYCRYPTODOME_DISABLE_DEEPBIND') is None:
             lib = ffi.dlopen(name, ffi.RTLD_DEEPBIND)
         else:
             lib = ffi.dlopen(name)


### PR DESCRIPTION
With this PR, setting `PYCRYPTODOME_DISABLE_DEEPBIND` to an empty string does disable `RTLD_DEEPBING`. Before it worked only for nonempty strings.