### PR TITLE
Fix ed25519_neg that causes inconsistent T

### DIFF
--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -285,6 +285,7 @@ EXPORT_SYM int ed25519_neg(Point *p)
     const uint32_t zero[10] = { 0 };
 
     sub_25519(p->X, zero, p->X);
+    sub_25519(p->T, zero, p->T);
     return 0;
 }
 


### PR DESCRIPTION
T should be negated along with X because T = XY/Z