### PR TITLE
unnecessary line removed

### DIFF
--- a/lib/Crypto/Cipher/ChaCha20_Poly1305.py
+++ b/lib/Crypto/Cipher/ChaCha20_Poly1305.py
@@ -304,8 +304,6 @@ def new(**kwargs):
     except KeyError as e:
         raise TypeError("Missing parameter %s" % e)
 
-        self._len_ct += len(plaintext)
-
     if len(key) != 32:
         raise ValueError("Key must be 32 bytes long")
 


### PR DESCRIPTION
Removed unnecessary orphaned line (self._len_ct += len(plaintext)) that would raise exception if it were not under the exception raised by the KeyError exception handling.

    try:
        key = kwargs.pop("key")
    except KeyError as e:
        raise TypeError("Missing parameter %s" % e)

        self._len_ct += len(plaintext)