### PR TITLE
Avoid null pointer dereference in `md2_digest`

### DIFF
--- a/src/MD2.c
+++ b/src/MD2.c
@@ -138,12 +138,12 @@ EXPORT_SYM int md2_digest(const hash_state *hs, uint8_t digest[16])
     uint8_t padding[16];
     unsigned padlen, i;
     hash_state temp;
-
-    assert(hs->count < 16);
  
     if (NULL==hs || digest==NULL)
         return ERR_NULL;
-  
+
+    assert(hs->count < 16);
+
     temp = *hs;
     padlen = 16 - hs->count;  /** 1..16 **/
     for(i=0; i<padlen; i++) { 


### PR DESCRIPTION
This PR moves the `assert(hs->count < 16);` _after_ the check if `hs` is not `null`.

Similar to #823.