### PR TITLE
Update ecc.rst

### DIFF
--- a/Doc/src/public_key/ecc.rst
+++ b/Doc/src/public_key/ecc.rst
@@ -38,7 +38,7 @@ and reimport it later::
 
 You can also export the public key, which is not sensitive::
 
-    >>> with open("mypublickey.pem", "wbt) as f:
+    >>> with open("mypublickey.pem", "wbt") as f:
     >>>     data = mykey.public_key().export_key()
 
 .. _ECC table:


### PR DESCRIPTION
Correct "SyntaxError: unterminated string literal" in documentation (pycryptodome.readthedocs.io/en/latest/src/public_key/ecc.html) example for public key export with ECC. 

Close string literal for open "mode" parameter. Should be "wbt" not "wbt.