### PR TITLE
typo fix in ECC.py

### DIFF
--- a/lib/Crypto/PublicKey/ECC.py
+++ b/lib/Crypto/PublicKey/ECC.py
@@ -64,7 +64,7 @@ class EccKey(object):
     :ivar curve: The **canonical** name of the curve as defined in the `ECC table`_.
     :vartype curve: string
 
-    :ivar pointQ: an ECC point representating the public component.
+    :ivar pointQ: an ECC point representing the public component.
     :vartype pointQ: :class:`EccPoint` or :class:`EccXPoint`
 
     :ivar d: A scalar that represents the private component
@@ -72,7 +72,7 @@ class EccKey(object):
              order of the generator point.
     :vartype d: integer
 
-    :ivar seed: A seed that representats the private component
+    :ivar seed: A seed that represents the private component
                 in EdDSA curves
                 (Ed25519, 32 bytes; Ed448, 57 bytes).
     :vartype seed: bytes


### PR DESCRIPTION
Just a trivial typo fix in ECC.py, irked me at work this week.

Representing and represents were initially misspelled as "representating" and "representats".

Can also just be added to [ecc_refactor](https://github.com/Legrandin/pycryptodome/tree/ecc_refactor) branch.

Thanks.