### PR TITLE
Use SPDX license expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -543,7 +543,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
     ],
-    license="BSD, Public Domain",
+    license="BSD-2-Clause AND Unlicense",
     packages=packages,
     package_dir={"": "lib"},
     package_data=package_data,


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) recommends the use of SPDX license expressions for the project metadata.

I believe the most direct analog to `BSD, Public Domain` would be **`BSD-2-Clause AND Unlicense`**.
It might also be possible to license the whole source code just as **`BSD-2-Clause`** since `Unlicense` is fully compatible.

https://spdx.org/licenses/BSD-2-Clause.html
https://spdx.org/licenses/Unlicense.html