### PR TITLE
Update native get_bit implementation to return bool

### DIFF
--- a/lib/Crypto/Math/_IntegerNative.py
+++ b/lib/Crypto/Math/_IntegerNative.py
@@ -263,7 +263,7 @@ class IntegerNative(IntegerBase):
                     raise ValueError("negative bit count")
         except OverflowError:
             result = 0
-        return result
+        return bool(result)
 
     # Extra
     def is_odd(self):


### PR DESCRIPTION
The native implementation of `get_bit` returned 0/1 as int while the GMP implementation and the type hint say `get_bit` returns a bool. Wrapped the result of `get_bit` in `IntegerNative` in `bool` to align the three.

See:
https://github.com/Legrandin/pycryptodome/blob/64506f73e9454f441cf2b6f8b2b45cf3c63a0cde/lib/Crypto/Math/_IntegerBase.pyi#L42

https://github.com/Legrandin/pycryptodome/blob/64506f73e9454f441cf2b6f8b2b45cf3c63a0cde/lib/Crypto/Math/_IntegerGMP.py#L635

```py 
IntegerGMP(1).get_bit(1)
> False
IntegerNative(1).get_bit(1)
> 0
```