### PR TITLE
Remove unused import

### DIFF
--- a/src/test/make_tests_poly1305_load_m.py
+++ b/src/test/make_tests_poly1305_load_m.py
@@ -2,7 +2,7 @@
 
 import struct
 
-from common import counter, make_main, split64
+from common import counter, make_main
 
 def make_test(secret):
 

--- a/src/test/make_tests_poly1305_load_r.py
+++ b/src/test/make_tests_poly1305_load_r.py
@@ -2,7 +2,7 @@
 
 import struct
 
-from common import counter, make_main, split64
+from common import counter, make_main
 
 
 def make_test(secret):


### PR DESCRIPTION
`split64` appears to be unused in these files.