### PR TITLE
Reduce complexity by using `max`

### DIFF
--- a/lib/Crypto/Random/random.py
+++ b/lib/Crypto/Random/random.py
@@ -67,9 +67,7 @@ class StrongRandom(object):
         if step == 0:
             raise ValueError("randrange step argument must not be zero")
 
-        num_choices = ceil_div(stop - start, step)
-        if num_choices < 0:
-            num_choices = 0
+        num_choices = max(ceil_div(stop - start, step), 0)
         if num_choices < 1:
             raise ValueError("empty range for randrange(%r, %r, %r)" % (start, stop, step))
 


### PR DESCRIPTION
This code can be simplified by using the `max` function.

This change also resolves the [`consider-using-max-builtin / R1731`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/consider-using-max-builtin.html) warning.