### PR TITLE
Simplify loops by using `enumerate`

### DIFF
--- a/lib/Crypto/SelfTest/Cipher/common.py
+++ b/lib/Crypto/SelfTest/Cipher/common.py
@@ -399,8 +399,7 @@ class MemoryviewTest(unittest.TestCase):
 def make_block_tests(module, module_name, test_data, additional_params=dict()):
     tests = []
     extra_tests_added = False
-    for i in range(len(test_data)):
-        row = test_data[i]
+    for i, row in enumerate(test_data):
 
         # Build the "params" dictionary with
         # - plaintext
@@ -461,8 +460,7 @@ def make_block_tests(module, module_name, test_data, additional_params=dict()):
 def make_stream_tests(module, module_name, test_data):
     tests = []
     extra_tests_added = False
-    for i in range(len(test_data)):
-        row = test_data[i]
+    for i, row in enumerate(test_data):
 
         # Build the "params" dictionary
         params = {}

--- a/lib/Crypto/SelfTest/Hash/common.py
+++ b/lib/Crypto/SelfTest/Hash/common.py
@@ -253,8 +253,7 @@ class MACSelfTest(unittest.TestCase):
 def make_hash_tests(module, module_name, test_data, digest_size, oid=None,
                     extra_params={}):
     tests = []
-    for i in range(len(test_data)):
-        row = test_data[i]
+    for i, row in enumerate(test_data):
         (expected, input) = map(tobytes,row[0:2])
         if len(row) < 3:
             description = repr(input)

--- a/lib/Crypto/SelfTest/Protocol/test_KDF.py
+++ b/lib/Crypto/SelfTest/Protocol/test_KDF.py
@@ -103,8 +103,7 @@ class PBKDF2_Tests(unittest.TestCase):
         def prf_SHA256(p,s):
             return HMAC.new(p,s,SHA256).digest()
 
-        for i in range(len(self._testData)):
-            v = self._testData[i]
+        for i, v in enumerate(self._testData):
             password = v[0]
             salt = t2b(v[1])
             out_len = v[2]

--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -307,8 +307,7 @@ def getStrongPrime(N, e=0, false_positive_prob=1e-6, randfunc=None):
 
         # look for suitable p[i] starting at y
         result = 0
-        for j in range(len(field)):
-            composite = field[j]
+        for j, composite in enumerate(field):
             # look for next canidate
             if composite:
                 continue


### PR DESCRIPTION
This PR resolves the [`consider-using-enumerate / C0200`](https://pylint.readthedocs.io/en/stable/user_guide/messages/convention/consider-using-enumerate.html) in the most _obvious_ cases.