### PR TITLE
Iterate dictionary directly

### DIFF
--- a/lib/Crypto/SelfTest/Protocol/test_HPKE.py
+++ b/lib/Crypto/SelfTest/Protocol/test_HPKE.py
@@ -51,7 +51,7 @@ class HPKE_Tests(unittest.TestCase):
         self.assertEqual(b'GHI', pt2)
 
     def test_round_trip(self):
-        for curve in self.curves.keys():
+        for curve in self.curves:
             for aead_id in HPKE.AEAD:
                 self.round_trip(curve, aead_id)
 


### PR DESCRIPTION
Resolves the [`consider-iterating-dictionary / C0201`](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/consider-iterating-dictionary.html). There are no other occurrences of that warning.