### PR TITLE
Resolve `unnecessary-pass`

### DIFF
--- a/lib/Crypto/Math/_IntegerBase.py
+++ b/lib/Crypto/Math/_IntegerBase.py
@@ -409,4 +409,3 @@ class IntegerBase(ABC):
             It is as long as the modulus would be, with zero padding
             on the left if needed.
         """
-        pass

--- a/lib/Crypto/Random/__init__.py
+++ b/lib/Crypto/Random/__init__.py
@@ -32,15 +32,12 @@ class _UrandomRNG(object):
 
     def flush(self):
         """Method provided for backward compatibility only."""
-        pass
 
     def reinit(self):
         """Method provided for backward compatibility only."""
-        pass
 
     def close(self):
         """Method provided for backward compatibility only."""
-        pass
         
 
 def new(*args, **kwargs):

--- a/lib/Crypto/Signature/pkcs1_15.py
+++ b/lib/Crypto/Signature/pkcs1_15.py
@@ -136,7 +136,6 @@ class PKCS115_SigScheme:
         #
         if em1 not in possible_em1:
             raise ValueError("Invalid signature")
-        pass
 
 
 def _EMSA_PKCS1_V1_5_ENCODE(msg_hash, emLen, with_hash_parameters=True):


### PR DESCRIPTION
This PR resolves the [`unnecessary-pass / W0107`](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unnecessary-pass.html) lint.