### PR TITLE
Fix integer overflow vulnerability in pkcs1_decode.c (#883)

### DIFF
--- a/src/pkcs1_decode.c
+++ b/src/pkcs1_decode.c
@@ -252,11 +252,12 @@ EXPORT_SYM int pkcs1_decode(const uint8_t *em, size_t len_em_output,
      * It can be len_em_output when the 0 is not present.
      * It can SIZE_T_MAX in case of other errors.
      */
-    pos = safe_search(em + 10, 0, len_em_output - 10) + 10;
+    pos = safe_search(em + 10, 0, len_em_output - 10);
     if (pos == SIZE_T_MAX) {
         result = -1;
         goto end;
     }
+    pos += 10;
 
     /*
      * selector is 0 if:


### PR DESCRIPTION
This commit fixes an integer overflow vulnerability in the pkcs1_decode function. Previously, the code was incrementing the position value returned by safe_search before checking if it was SIZE_T_MAX (error condition). This could lead to an overflow when adding 10 to SIZE_T_MAX, causing the subsequent error check to fail.

The fix ensures we check for the error condition before performing the addition, preventing the potential overflow vulnerability.

Fixes #883