### PR TITLE
Feedback mode and Double pipeline mode from SP800-108 rev1 upd1

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,3 +49,4 @@ Hannes van Niekerk
 Stefan Seering
 Koki Takahashi
 Lauro de Lima
+Emmanuel Konan

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -4,6 +4,15 @@ Changelog
 3.24.0 (under development)
 ++++++++++++++++++++++++++
 
+New features
+---------------
+* Improvements to ``SP800_108_Counter``:
+  * Updated function description: Updated reference from NIST SP 800-108r1 to NIST SP 800-108r1-upd1.
+  * Renamed variables for clarity and reuse.
+  * Avoided redundant operations.
+  * Allowed null bytes in the context, as they are not prohibited by the standard.
+* Added ``SP800_108_Feedback`` and ``SP800_108_Double_Pipeline`` from NIST SP 800-108r1-upd1 
+
 Resolved issues
 ---------------
 * GH#875: Fixed the Object Identifiers (OID) for BLAKE2.

--- a/Doc/src/protocol/kdf.rst
+++ b/Doc/src/protocol/kdf.rst
@@ -135,8 +135,8 @@ If the PRF has a fixed-length output,
 you can evaluate the PRF multiple times and concatenate the results until you collect enough derived keying material.
 
 This function implements such type of KDF, where a counter contributes to each invokation of the PRF, as defined in
-`NIST SP 800-108 Rev 1 <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf>`_.
-The NIST standard only allows the use of HMAC (recommended) and CMAC (not recommended) as PRF.
+`NIST SP 800-108r1-upd1 <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf>`_.
+According to the NIST standard, only HMAC, CMAC, and KMAC are permitted as PRFs. In general, HMAC and KMAC should be preferred over CMAC (see details in the standard).
 
 This KDF is not suitable for deriving keys from a password.
 
@@ -169,6 +169,86 @@ Example 3 (CMAC as PRF, two AES256 keys to derive)::
     >> key_A, key_B = SP800_108_Counter(secret, 32, prf, num_keys=2, label=b'Key AB')
 
 .. autofunction:: Crypto.Protocol.KDF.SP800_108_Counter
+
+.. _sp800-108-feeedback:
+
+SP 800-108 Feedback Mode
+++++++++++++++++++++++++
+
+This function implements a KDF, where the output of one invocation of the PRF is used as input for the next invocation of the PRF, as defined in
+`NIST SP 800-108r1-upd1 <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf>`_. A counter may also be included, as in Counter Mode, but its use is optional. An initial value (IV) can optionally be provided as input to the first invocation of the PRF.
+
+This KDF is not suitable for deriving keys from a password.
+
+Example 1 (HMAC as PRF, one AES128 key to derive)::
+
+    >> from Crypto.Hash import SHA256, HMAC
+    >>
+    >> def prf(s, x):
+    >>     return HMAC.new(s, x, SHA256).digest()
+    >>
+    >> key_derived = SP800_108_Feedback(secret, 16, prf, label=b'Key A', context=b"Context 1", iv=b"IV", with_counter=True)
+
+Example 2 (HMAC as PRF, two AES128 keys to derive)::
+
+    >> from Crypto.Hash import SHA256, HMAC
+    >>
+    >> def prf(s, x):
+    >>     return HMAC.new(s, x, SHA256).digest()
+    >>
+    >> key_A, key_B = SP800_108_Feedback(secret, 16, prf, num_keys=2, label=b'Key AB', context=b"Context 2", iv=b"IV", with_counter=False)
+
+Example 3 (CMAC as PRF, two AES256 keys to derive)::
+
+    >> from Crypto.Cipher import AES
+    >> from Crypto.Hash import SHA256, CMAC
+    >>
+    >> def prf(s, x):
+    >>     return CMAC.new(s, x, AES).digest()
+    >>
+    >> key_A, key_B = SP800_108_Feedback(secret, 32, prf, num_keys=2, label=b'Key AB')
+
+.. autofunction:: Crypto.Protocol.KDF.SP800_108_Feedback
+
+.. _sp800-108-double-pipeline:
+
+SP 800-108 Double Pipeline Mode
+++++++++++++++++++++++++
+
+This function implements a KDF that combines aspects of both Counter Mode and Feedback Mode, as defined in
+`NIST SP 800-108r1-upd1 <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf>`_. A counter can also be used as in the counter mode, it is optional.
+
+This KDF is not suitable for deriving keys from a password.
+
+Example 1 (HMAC as PRF, one AES128 key to derive)::
+
+    >> from Crypto.Hash import SHA256, HMAC
+    >>
+    >> def prf(s, x):
+    >>     return HMAC.new(s, x, SHA256).digest()
+    >>
+    >> key_derived = SP800_108_Double_Pipeline(secret, 16, prf, label=b'Key A', context=b"Context 1", with_counter=True)
+
+Example 2 (HMAC as PRF, two AES128 keys to derive)::
+
+    >> from Crypto.Hash import SHA256, HMAC
+    >>
+    >> def prf(s, x):
+    >>     return HMAC.new(s, x, SHA256).digest()
+    >>
+    >> key_A, key_B = SP800_108_Double_Pipeline(secret, 16, prf, num_keys=2, label=b'Key AB', context=b"Context 2", with_counter=False)
+
+Example 3 (CMAC as PRF, two AES256 keys to derive)::
+
+    >> from Crypto.Cipher import AES
+    >> from Crypto.Hash import SHA256, CMAC
+    >>
+    >> def prf(s, x):
+    >>     return CMAC.new(s, x, AES).digest()
+    >>
+    >> key_A, key_B = SP800_108_Double_Pipeline(secret, 32, prf, num_keys=2, label=b'Key AB')
+
+.. autofunction:: Crypto.Protocol.KDF.SP800_108_Double_Pipeline
 
 PBKDF1
 +++++++

--- a/lib/Crypto/Protocol/KDF.pyi
+++ b/lib/Crypto/Protocol/KDF.pyi
@@ -30,15 +30,49 @@ def bcrypt(password: Union[bytes, str], cost: int, salt: Optional[bytes]=None) -
 def bcrypt_check(password: Union[bytes, str], bcrypt_hash: Union[bytes, bytearray, str]) -> None: ...
 
 @overload
-def SP800_108_Counter(master: Buffer,
+def SP800_108_Counter(master_key: Buffer,
                       key_len: int,
                       prf: PRF,
                       num_keys: Literal[None] = None,
                       label: Buffer = b'', context: Buffer = b'') -> bytes: ...
 
 @overload
-def SP800_108_Counter(master: Buffer,
+def SP800_108_Counter(master_key: Buffer,
                       key_len: int,
                       prf: PRF,
                       num_keys: int,
                       label: Buffer = b'', context: Buffer = b'') -> Tuple[bytes]: ...
+
+@overload
+def SP800_108_Feedback(master_key: Buffer,
+                      key_len: int,
+                      prf: PRF,
+                      num_keys: Literal[None] = None,
+                      label: Buffer = b'',
+                      context: Buffer = b'',
+                      iv=b"", with_counter=True) -> bytes: ...
+
+@overload
+def SP800_108_Feedback(master_key: Buffer,
+                      key_len: int,
+                      prf: PRF,
+                      num_keys: Literal[None] = None,
+                      label: Buffer = b'',
+                      context: Buffer = b'',
+                      iv=b"", with_counter=True) -> Tuple[bytes]: ...
+
+@overload
+def SP800_108_Double_Pipeline(master_key: Buffer,
+                      key_len: int,
+                      prf: PRF,
+                      num_keys: Literal[None] = None,
+                      label: Buffer = b'',
+                      context: Buffer = b'', with_counter=True) -> bytes: ...
+
+@overload
+def SP800_108_Double_Pipeline(master_key: Buffer,
+                      key_len: int,
+                      prf: PRF,
+                      num_keys: Literal[None] = None,
+                      label: Buffer = b'',
+                      context: Buffer = b'', with_counter=True) -> Tuple[bytes]: ...


### PR DESCRIPTION
* Improvements to ``SP800_108_Counter``:
  * Updated function description: Updated reference from NIST SP 800-108r1 to NIST SP 800-108r1-upd1.
  * Renamed variables for clarity and reuse.
  * Avoided redundant operations.
  * Allowed null bytes in the context, as they are not prohibited by the standard.
* Added ``SP800_108_Feedback`` and ``SP800_108_Double_Pipeline`` from NIST SP 800-108r1-upd1 