### PR TITLE
NIST KDF SP800-108 | Allow Null Byte in Context

### DIFF
--- a/lib/Crypto/Protocol/KDF.py
+++ b/lib/Crypto/Protocol/KDF.py
@@ -609,12 +609,10 @@ def SP800_108_Counter(master, key_len, prf, num_keys=None, label=b'', context=b'
         By default, only 1 key is derived.
      label (byte string):
         Optional description of the purpose of the derived keys.
-        It must not contain zero bytes.
      context (byte string):
         Optional information pertaining to
         the protocol that uses the keys, such as the identity of the
         participants, nonces, session IDs, etc.
-        It must not contain zero bytes.
 
     Return:
         - a byte string (if ``num_keys`` is not specified), or
@@ -623,9 +621,6 @@ def SP800_108_Counter(master, key_len, prf, num_keys=None, label=b'', context=b'
 
     if num_keys is None:
         num_keys = 1
-
-    if context.find(b'\x00') != -1:
-        raise ValueError("Null byte found in context")
 
     key_len_enc = long_to_bytes(key_len * num_keys * 8, 4)
     output_len = key_len * num_keys

--- a/lib/Crypto/SelfTest/Protocol/test_KDF.py
+++ b/lib/Crypto/SelfTest/Protocol/test_KDF.py
@@ -716,7 +716,7 @@ def load_hash_by_name(hash_name):
 
 class SP800_108_Counter_Tests(unittest.TestCase):
 
-    def test_negative_zeroes(self):
+    def test_zeroes(self):
         def prf(s, x):
             return HMAC.new(s, x, SHA256).digest()
 
@@ -724,8 +724,10 @@ class SP800_108_Counter_Tests(unittest.TestCase):
             _ = SP800_108_Counter(b'0' * 16, 1, prf, label=b'A\x00B')
         except ValueError:
             self.fail('SP800_108_Counter failed with zero in label')
-        self.assertRaises(ValueError, SP800_108_Counter, b'0' * 16, 1, prf,
-                          context=b'A\x00B')
+        try:
+            _ = SP800_108_Counter(b'0' * 16, 1, prf, context=b'A\x00B')
+        except ValueError:
+            self.fail('SP800_108_Counter failed with zero in context')
 
     def test_multiple_keys(self):
         def prf(s, x):


### PR DESCRIPTION
This PR removes the check for null bytes in the context of a NIST KDF SP800-108 operation.
The relevant documentation and test are also updated.

Null bytes are not explicitly forbidden in the context or label by the NIST specification, and there are other SP800-108 implementations that do not make this check. 