### PR TITLE
docs: recommend SHA-256 for new OAEP usage

### DIFF
--- a/Doc/src/cipher/oaep.rst
+++ b/Doc/src/cipher/oaep.rst
@@ -10,23 +10,28 @@ where it is called ``RSAES-OAEP``.
 It can only encrypt messages slightly shorter than the RSA modulus (a few
 hundred bytes).
 
+The default hash algorithm is SHA-1, as specified in RFC8017. However,
+applications should use a stronger hash function, such as SHA-256,
+whenever interoperability with legacy protocols does not require SHA-1.
+
 The following example shows how you encrypt data by means of
 the recipient's **public key** (here assumed to be
 available locally in a file called ``public.pem``)::
 
         >>> from Crypto.Cipher import PKCS1_OAEP
+        >>> from Crypto.Hash import SHA256
         >>> from Crypto.PublicKey import RSA
         >>>
         >>> message = b'You can attack now!'
         >>> key = RSA.importKey(open('public.pem').read())
-        >>> cipher = PKCS1_OAEP.new(key)
+        >>> cipher = PKCS1_OAEP.new(key, hashAlgo=SHA256)
         >>> ciphertext = cipher.encrypt(message)
 
 The recipient uses its own **private key** to decrypt the message.
 We assume the key is stored in a file called ``private.pem``::
 
         >>> key = RSA.importKey(open('private.pem').read())
-        >>> cipher = PKCS1_OAEP.new(key)
+        >>> cipher = PKCS1_OAEP.new(key, hashAlgo=SHA256)
         >>> message = cipher.decrypt(ciphertext)
 
 .. warning::

--- a/Doc/src/examples.rst
+++ b/Doc/src/examples.rst
@@ -189,9 +189,10 @@ As in the first example, we use the EAX mode to allow detection of unauthorized 
 
 .. code-block:: python
 
+    from Crypto.Cipher import AES, PKCS1_OAEP
+    from Crypto.Hash import SHA256
     from Crypto.PublicKey import RSA
     from Crypto.Random import get_random_bytes
-    from Crypto.Cipher import AES, PKCS1_OAEP
 
     data = "I met aliens in UFO. Here is the map.".encode("utf-8")
 
@@ -200,7 +201,7 @@ As in the first example, we use the EAX mode to allow detection of unauthorized 
 
     # Encrypt the session key with the public RSA key
 
-    cipher_rsa = PKCS1_OAEP.new(recipient_key)
+    cipher_rsa = PKCS1_OAEP.new(recipient_key, hashAlgo=SHA256)
     enc_session_key = cipher_rsa.encrypt(session_key)
 
     # Encrypt the data with the AES session key
@@ -219,8 +220,9 @@ first, and with that the rest of the file:
 
 .. code-block:: python
 
-    from Crypto.PublicKey import RSA
     from Crypto.Cipher import AES, PKCS1_OAEP
+    from Crypto.Hash import SHA256
+    from Crypto.PublicKey import RSA
 
     private_key = RSA.import_key(open("private.pem").read())
 
@@ -231,7 +233,7 @@ first, and with that the rest of the file:
         ciphertext = f.read()
 
     # Decrypt the session key with the private RSA key
-    cipher_rsa = PKCS1_OAEP.new(private_key)
+    cipher_rsa = PKCS1_OAEP.new(private_key, hashAlgo=SHA256)
     session_key = cipher_rsa.decrypt(enc_session_key)
 
     # Decrypt the data with the AES session key

--- a/lib/Crypto/Cipher/PKCS1_OAEP.py
+++ b/lib/Crypto/Cipher/PKCS1_OAEP.py
@@ -45,7 +45,9 @@ class PKCS1OAEP_Cipher:
          hashAlgo : hash object
                 The hash function to use. This can be a module under `Crypto.Hash`
                 or an existing hash object created from any of such modules. If not specified,
-                `Crypto.Hash.SHA1` is used.
+                `Crypto.Hash.SHA1` is used, matching the RSAES-OAEP default
+                defined in RFC8017. New protocols should use SHA-256 or a stronger
+                hash function.
          mgfunc : callable
                 A mask generation function that accepts two parameters: a string to
                 use as seed, and the lenth of the mask to generate, in bytes.
@@ -205,7 +207,9 @@ def new(key, hashAlgo=None, mgfunc=None, label=b'', randfunc=None):
     :param hashAlgo:
       The hash function to use. This can be a module under `Crypto.Hash`
       or an existing hash object created from any of such modules.
-      If not specified, `Crypto.Hash.SHA1` is used.
+      If not specified, `Crypto.Hash.SHA1` is used, matching the RSAES-OAEP
+      default defined in RFC8017. New protocols should use SHA-256 or a stronger
+      hash function.
     :type hashAlgo: hash object
 
     :param mgfunc:


### PR DESCRIPTION
Addresses #906.

## Summary

This keeps the RSAES-OAEP default hash algorithm as SHA-1 for compatibility with RFC 8017 and existing ciphertexts, but updates the documentation to recommend SHA-256 explicitly for new protocols.

Changes included:

- Document that SHA-1 remains the default because it is the RFC 8017 RSAES-OAEP default.
- Recommend SHA-256 or stronger hashes for new OAEP usage when legacy interoperability does not require SHA-1.
- Update OAEP examples to pass `hashAlgo=SHA256`.
- Clarify the `hashAlgo` docstring in `Crypto.Cipher.PKCS1_OAEP`.

## Rationale

Changing the default hash algorithm would silently break interoperability and decryption of existing OAEP ciphertexts created with the current default. A documentation/example update gives new users safer guidance without introducing a backward compatibility break.

## Tests

- `python3 setup.py build_ext -i`
- `env PYTHONPATH=lib:test_vectors python3 -c 'import unittest; from Crypto.SelfTest.Cipher import test_pkcs1_oaep; suite=unittest.TestSuite(test_pkcs1_oaep.get_tests({"slow_tests": False, "wycheproof_warnings": False})); result=unittest.TextTestRunner(verbosity=2).run(suite); raise SystemExit(0 if result.wasSuccessful() else 1)'`
- `git diff --check`