### PR TITLE
Avoid private-key PEM markers in installed self-tests

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,8 @@ Changelog
 Resolved issues
 ---------------
 * GH#875: Fixed the Object Identifiers (OID) for BLAKE2.
+* GH#904: Removed PEM private key markers from installed self-test fixtures,
+  to avoid false positives with artifact security scanners.
 
 3.23.0 (17 May 2025)
 ++++++++++++++++++++++++++

--- a/lib/Crypto/SelfTest/Cipher/test_pkcs1_15.py
+++ b/lib/Crypto/SelfTest/Cipher/test_pkcs1_15.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import unittest
 
 from Crypto.PublicKey import RSA
-from Crypto.SelfTest.st_common import list_test_cases, a2b_hex
+from Crypto.SelfTest.st_common import list_test_cases, a2b_hex, make_pem
 from Crypto import Random
 from Crypto.Cipher import PKCS1_v1_5 as PKCS
 from Crypto.Util.py3compat import b
@@ -68,8 +68,7 @@ class PKCS1_15_Tests(unittest.TestCase):
                 #
                 (
                 # Private key
-                '''-----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQDAiAnvIAOvqVwJTaYzsKnefZftgtXGE2hPJppGsWl78yz9jeXY
+                make_pem('RSA PRIVATE KEY', """MIICXAIBAAKBgQDAiAnvIAOvqVwJTaYzsKnefZftgtXGE2hPJppGsWl78yz9jeXY
 W/FxX/gTPURArNhdnhP6n3p2ZaDIBrO2zizbgIXs0IsljTTcr4vnI8fMXzyNUOjA
 zP3nzMqZDZK6757XQAobOssMkBFqRWwilT/3DsBhRpl3iMUhF+wvpTSHewIDAQAB
 AoGAC4HV/inOrpgTvSab8Wj0riyZgQOZ3U3ZpSlsfR8ra9Ib9Uee3jCYnKscu6Gk
@@ -81,8 +80,7 @@ d3XHFBBQWA6xcvQb5w+VVEJZzw64y25sHwJBAMYReRl6SzL0qA0wIYrYWrOt8JeQ
 8mthulcWHXmqTgC6FEXP9Es5GD7/fuKl4wqLKZgIbH4nqvvGay7xXLCXD/ECQH9a
 1JYNMtRen5unSAbIOxRcKkWz92F0LKpm9ZW/S9vFHO+mBcClMGoKJHiuQxLBsLbT
 NtEZfSJZAeS2sUtn3/0CQDb2M2zNBTF8LlM0nxmh0k9VGm5TVIyBEMcipmvOgqIs
-HKukWBcq9f/UOmS0oEhai/6g+Uf7VHJdWaeO5LzuvwU=
------END RSA PRIVATE KEY-----''',
+HKukWBcq9f/UOmS0oEhai/6g+Uf7VHJdWaeO5LzuvwU="""),
                 # Plaintext
                 '''THIS IS PLAINTEXT\x0A''',
                 # Ciphertext

--- a/lib/Crypto/SelfTest/Protocol/test_ecdh.py
+++ b/lib/Crypto/SelfTest/Protocol/test_ecdh.py
@@ -7,7 +7,7 @@ from Crypto.Util.py3compat import bord
 
 from Crypto.Hash import SHA256
 from Crypto.PublicKey import ECC
-from Crypto.SelfTest.st_common import list_test_cases
+from Crypto.SelfTest.st_common import list_test_cases, make_pem
 from Crypto.SelfTest.loader import load_test_vectors, load_test_vectors_wycheproof
 
 from Crypto.Protocol import DH
@@ -151,12 +151,20 @@ class TestVectorsECDHWycheproof(unittest.TestCase):
 
 class ECDH_Tests(unittest.TestCase):
 
-    static_priv = ECC.import_key('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg9VHFVKh2a1aVFifH\n+BiyNaRa2kttEg3165Ye/dJxJ7KhRANCAARImIEXro5ZOcyWU2mq/+d79FEZXtTA\nbKkz1aICQXihQdCMzRNbeNtC9LFLzhu1slRKJ2xsDAlw9r6w6vwtkRzr\n-----END PRIVATE KEY-----')
-    static_pub = ECC.import_key('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgHhmv8zmZ+Nw8fsZd\ns8tlZflyfw2NE1CRS9DWr3Y3O46hRANCAAS3hZVUCbk+uk3w4S/YOraEVGG+WYpk\nNO/vrwzufUUks2GV2OnBQESe0EBk4Jq8gn4ij8Lvs3rZX2yT+XfeATYd\n-----END PRIVATE KEY-----').public_key()
+    static_priv = ECC.import_key(make_pem('PRIVATE KEY', """MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg9VHFVKh2a1aVFifH
++BiyNaRa2kttEg3165Ye/dJxJ7KhRANCAARImIEXro5ZOcyWU2mq/+d79FEZXtTA
+bKkz1aICQXihQdCMzRNbeNtC9LFLzhu1slRKJ2xsDAlw9r6w6vwtkRzr"""))
+    static_pub = ECC.import_key(make_pem('PRIVATE KEY', """MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgHhmv8zmZ+Nw8fsZd
+s8tlZflyfw2NE1CRS9DWr3Y3O46hRANCAAS3hZVUCbk+uk3w4S/YOraEVGG+WYpk
+NO/vrwzufUUks2GV2OnBQESe0EBk4Jq8gn4ij8Lvs3rZX2yT+XfeATYd""")).public_key()
 
-    eph_priv = ECC.import_key('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGPdJmFFFKzLPspIr\nE1T2cEjeIf4ajS9CpneP0e2b3AyhRANCAAQBexAA5BYDcXHs2KOksTYUsst4HhPt\nkp0zkgI2virc3OGJFNGPaCCPfFCQJHwLRaEpiq3SoQlgoBwSc8ZPsl3y\n-----END PRIVATE KEY-----')
+    eph_priv = ECC.import_key(make_pem('PRIVATE KEY', """MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgGPdJmFFFKzLPspIr
+E1T2cEjeIf4ajS9CpneP0e2b3AyhRANCAAQBexAA5BYDcXHs2KOksTYUsst4HhPt
+kp0zkgI2virc3OGJFNGPaCCPfFCQJHwLRaEpiq3SoQlgoBwSc8ZPsl3y"""))
 
-    eph_pub = ECC.import_key('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghaVZXElSEGEojFKF\nOU0JCpxWUWHvWQUR81gwWrOp76ShRANCAATi1Ib2K+YR3AckD8wxypWef7pw5PRw\ntBaB3RDPyE7IjHZC6yu1DbcXoCdtaw+F5DM+4zpl59n5ZaIy/Yl1BdIy\n-----END PRIVATE KEY-----')
+    eph_pub = ECC.import_key(make_pem('PRIVATE KEY', """MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghaVZXElSEGEojFKF
+OU0JCpxWUWHvWQUR81gwWrOp76ShRANCAATi1Ib2K+YR3AckD8wxypWef7pw5PRw
+tBaB3RDPyE7IjHZC6yu1DbcXoCdtaw+F5DM+4zpl59n5ZaIy/Yl1BdIy"""))
 
     def test_1(self):
         # C(0, 2s)

--- a/lib/Crypto/SelfTest/PublicKey/test_import_DSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_DSA.py
@@ -142,9 +142,7 @@ tPG+TJKpGYb7pVk=
         self.assertEqual(self.der_private, encoded)
 
     # 4.
-    pem_private="""\
------BEGIN DSA PRIVATE KEY-----
-MIIBuwIBAAKBgQDnVu4XF/S2eUx8IUckoZdjdCxFVytLP4/ztE876fRM4DmidXaV
+    pem_private = make_pem('DSA PRIVATE KEY', """MIIBuwIBAAKBgQDnVu4XF/S2eUx8IUckoZdjdCxFVytLP4/ztE876fRM4DmidXaV
 7JFWl9p075FPzRsFZg4kGcdh1jn0XS15uALb0j56uLgbR5o4Dh8wkyWEuioLlVAy
 NC68g8tcqQbnsNfNb+ZWzstMi1p3EjqMZ1CkgeOwYFev9qpuumILgy1gwwIVAK0y
 9IzTrgxFoZimH6S14gMgdjsjAoGAed/cPWFP5jX8636urjcY3C7++0UoKZOsZ0nc
@@ -153,8 +151,7 @@ BArKcLjVggWZcRkA77yWGBLDVd2b7/4JgdqFxVSAdLQcVq5D/TANiSYuTv2JlD+Z
 plGwOIgCgYEAgzUqaaEy80hD0qDrmVv/Ti8IOnPwBJ0skeovDOQ9FEq9pIGZ5LAD
 xXCor4MwPUUQX2BsXEjZJaQO2cJjDC+kzb+DhTneuaKfkZCF8gRjafYnyoSyyx4s
 eUBWS2cPljqxFk1OLKK/b/058S9UiSi/TS0bXmmAtPG+TJKpGYb7pVkCFF69mj8L
-ggadmEIJhrMUIVAldWBl
------END DSA PRIVATE KEY-----"""
+ggadmEIJhrMUIVAldWBl""")
 
     def testImportKey4(self):
         for pem in (self.pem_private, tostr(self.pem_private)):
@@ -204,16 +201,13 @@ ggadmEIJhrMUIVAldWBl
         self.assertEqual(self.der_pkcs8, encoded)
 
     # 6.
-    pem_pkcs8="""\
------BEGIN PRIVATE KEY-----
-MIIBSgIBADCCASsGByqGSM44BAEwggEeAoGBAOdW7hcX9LZ5THwhRyShl2N0LEVX
+    pem_pkcs8 = make_pem('PRIVATE KEY', """MIIBSgIBADCCASsGByqGSM44BAEwggEeAoGBAOdW7hcX9LZ5THwhRyShl2N0LEVX
 K0s/j/O0Tzvp9EzgOaJ1dpXskVaX2nTvkU/NGwVmDiQZx2HWOfRdLXm4AtvSPnq4
 uBtHmjgOHzCTJYS6KguVUDI0LryDy1ypBuew181v5lbOy0yLWncSOoxnUKSB47Bg
 V6/2qm66YguDLWDDAhUArTL0jNOuDEWhmKYfpLXiAyB2OyMCgYB539w9YU/mNfzr
 fq6uNxjcLv77RSgpk6xnSdyDwiPYwYhyljFrOwtURmz0RPNLguNVTQuQp3j6rxMG
 8CXa5qPjbH+T3VusQFK5I3AECspwuNWCBZlxGQDvvJYYEsNV3Zvv/gmB2oXFVIB0
-tBxWrkP9MA2JJi5O/YmUP5mmUbA4iAQWAhRevZo/C4IGnZhCCYazFCFQJXVgZQ==
------END PRIVATE KEY-----"""
+tBxWrkP9MA2JJi5O/YmUP5mmUbA4iAQWAhRevZo/C4IGnZhCCYazFCFQJXVgZQ==""")
 
     def testImportKey6(self):
         for pem in (self.pem_pkcs8, tostr(self.pem_pkcs8)):
@@ -252,9 +246,7 @@ tBxWrkP9MA2JJi5O/YmUP5mmUbA4iAQWAhRevZo/C4IGnZhCCYazFCFQJXVgZQ==
         self.assertEqual(self.ssh_pub, encoded)
 
     # 8. Encrypted OpenSSL/OpenSSH
-    pem_private_encrypted="""\
------BEGIN DSA PRIVATE KEY-----
-Proc-Type: 4,ENCRYPTED
+    pem_private_encrypted = make_pem('DSA PRIVATE KEY', """Proc-Type: 4,ENCRYPTED
 DEK-Info: AES-128-CBC,70B6908939D65E9F2EB999E8729788CE
 
 4V6GHRDpCrdZ8MBjbyp5AlGUrjvr2Pn2e2zVxy5RBt4FBj9/pa0ae0nnyUPMLSUU
@@ -266,8 +258,7 @@ nnPqHxmhMQozBWzYM4mQuo3XbF2WlsNFbOzFVyGhw1Bx1s91qvXBVWJh2ozrW0s6
 HYDV7ZkcTml/4kjA/d+mve6LZ8kuuR1qCiZx6rkffhh1gDN/1Xz3HVvIy/dQ+h9s
 5zp7PwUoWbhqp3WCOr156P6gR8qo7OlT6wMh33FSXK/mxikHK136fV2shwTKQVII
 rJBvXpj8nACUmi7scKuTWGeUoXa+dwTZVVe+b+L2U1ZM7+h/neTJiXn7u99PFUwu
-xVJtxaV37m3aXxtCsPnbBg==
------END DSA PRIVATE KEY-----"""
+xVJtxaV37m3aXxtCsPnbBg==""")
 
     def testImportKey8(self):
         for pem in (self.pem_private_encrypted, tostr(self.pem_private_encrypted)):
@@ -292,17 +283,14 @@ xVJtxaV37m3aXxtCsPnbBg==
 
     # 9. Encrypted PKCS8
     # pbeWithMD5AndDES-CBC
-    pem_pkcs8_encrypted="""\
------BEGIN ENCRYPTED PRIVATE KEY-----
-MIIBcTAbBgkqhkiG9w0BBQMwDgQI0GC3BJ/jSw8CAggABIIBUHc1cXZpExIE9tC7
+    pem_pkcs8_encrypted = make_pem('ENCRYPTED PRIVATE KEY', """MIIBcTAbBgkqhkiG9w0BBQMwDgQI0GC3BJ/jSw8CAggABIIBUHc1cXZpExIE9tC7
 7ryiW+5ihtF2Ekurq3e408GYSAu5smJjN2bvQXmzRFBz8W38K8eMf1sbWroZ4+zn
 kZSbb9nSm5kAa8lR2+oF2k+WRswMR/PTC3f/D9STO2X0QxdrzKgIHEcSGSHp5jTx
 aVvbkCDHo9vhBTl6S3ogZ48As/MEro76+9igUwJ1jNhIQZPJ7e20QH5qDpQFFJN4
 CKl2ENSEuwGiqBszItFy4dqH0g63ZGZV/xt9wSO9Rd7SK/EbA/dklOxBa5Y/VItM
 gnIhs9XDMoGYyn6F023EicNJm6g/bVQk81BTTma4tm+12TKGdYm+QkeZvCOMZylr
 Wv67cKwO3cAXt5C3QXMDgYR64XvuaT5h7C0igMp2afSXJlnbHEbFxQVJlv83T4FM
-eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==
------END ENCRYPTED PRIVATE KEY-----"""
+eZ4k+NQDbEL8GiHmFxzDWQAuPPZKJWEEEV2p/To+WOh+kSDHQw==""")
 
     def testImportKey9(self):
         for pem in (self.pem_pkcs8_encrypted, tostr(self.pem_pkcs8_encrypted)):

--- a/lib/Crypto/SelfTest/PublicKey/test_import_ECC.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_ECC.py
@@ -34,7 +34,7 @@ import warnings
 import unittest
 from binascii import unhexlify
 
-from Crypto.SelfTest.st_common import list_test_cases
+from Crypto.SelfTest.st_common import list_test_cases, make_pem
 from Crypto.Util.py3compat import bord, tostr, FileNotFoundError
 from Crypto.Util.asn1 import DerSequence, DerBitString
 from Crypto.Util.number import bytes_to_long
@@ -187,12 +187,10 @@ class TestImport(unittest.TestCase):
 
     def test_mismatch(self):
         # The private key does not match the public key
-        mismatch = """-----BEGIN PRIVATE KEY-----
-MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAAAAAAAAAAAAAAAAAA
+        mismatch = make_pem('PRIVATE KEY', """MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAAAAAAAAAAAAAAAAAA
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJChZANiAAQarFRaqflo
 I+d61SRvU8Za2EurxtW20eZzca7dnNYMYf3boIkDuAUU7FfO7l0/4iGzzvfUinng
-o4N+LZfQYcTxmdwlkWOrfzCjtHDix6EznPO/LlxTsV+zfTJ/ijTjeXk=
------END PRIVATE KEY-----"""
+o4N+LZfQYcTxmdwlkWOrfzCjtHDix6EznPO/LlxTsV+zfTJ/ijTjeXk=""")
         self.assertRaises(ValueError, ECC.import_key, mismatch)
 
     def test_import_private_rfc5915_none(self):
@@ -1120,18 +1118,14 @@ class TestExport_P192(unittest.TestCase):
     def test_compressed_curve(self):
 
         # Compressed P-192 curve (Y-point is even)
-        pem1 = """-----BEGIN EC PRIVATE KEY-----
-        MF8CAQEEGHvhXmIW95JxZYfd4AUPu9BwknjuvS36aqAKBggqhkjOPQMBAaE0AzIA
-        BLJZCyTu35DQIlqvMlBynn3k1Ig+dWfg/brRhHecxptrbloqFSP8ITw0CwbGF+2X
-        5g==
-        -----END EC PRIVATE KEY-----"""
+        pem1 = make_pem('EC PRIVATE KEY', """MF8CAQEEGHvhXmIW95JxZYfd4AUPu9BwknjuvS36aqAKBggqhkjOPQMBAaE0AzIA
+BLJZCyTu35DQIlqvMlBynn3k1Ig+dWfg/brRhHecxptrbloqFSP8ITw0CwbGF+2X
+5g==""")
 
         # Compressed P-192 curve (Y-point is odd)
-        pem2 = """-----BEGIN EC PRIVATE KEY-----
-        MF8CAQEEGA3rAotUaWl7d47eX6tz9JmLzOMJwl13XaAKBggqhkjOPQMBAaE0AzIA
-        BG4tHlTBBBGokcWmGm2xubVB0NvPC/Ou5AYwivs+3iCxmEjsymVAj6iiuX2Lxr6g
-        /Q==
-        -----END EC PRIVATE KEY-----"""
+        pem2 = make_pem('EC PRIVATE KEY', """MF8CAQEEGA3rAotUaWl7d47eX6tz9JmLzOMJwl13XaAKBggqhkjOPQMBAaE0AzIA
+BG4tHlTBBBGokcWmGm2xubVB0NvPC/Ou5AYwivs+3iCxmEjsymVAj6iiuX2Lxr6g
+/Q==""")
 
         key1 = ECC.import_key(pem1)
         low16 = int(key1.pointQ.y % 65536)
@@ -1375,18 +1369,14 @@ class TestExport_P224(unittest.TestCase):
     def test_compressed_curve(self):
 
         # Compressed P-224 curve (Y-point is even)
-        pem1 = """-----BEGIN EC PRIVATE KEY-----
-        MGgCAQEEHPYicBNI9nd6wDKAX2l+f3A0Q+KWUQeMqSt5GoOgBwYFK4EEACGhPAM6
-        AATCL6rUIDT14zXKoS5GQUMDP/tpc+1iI/FyEZikt2roKDkhU5q08srmqaysbfJN
-        eUr7Xf1lnCVGag==
-        -----END EC PRIVATE KEY-----"""
+        pem1 = make_pem('EC PRIVATE KEY', """MGgCAQEEHPYicBNI9nd6wDKAX2l+f3A0Q+KWUQeMqSt5GoOgBwYFK4EEACGhPAM6
+AATCL6rUIDT14zXKoS5GQUMDP/tpc+1iI/FyEZikt2roKDkhU5q08srmqaysbfJN
+eUr7Xf1lnCVGag==""")
 
         # Compressed P-224 curve (Y-point is odd)
-        pem2 = """-----BEGIN EC PRIVATE KEY-----
-        MGgCAQEEHEFjbaVPLJ3ngZyCibCvT0RLUqSlHjC5Z3e0FtugBwYFK4EEACGhPAM6
-        AAT5IvL2V6m48y1JLMGr6ZbnOqNKP9hMf9mxyVkk6/SaRoBoJVkXrNIpYL0P7DS7
-        QF8E/OGeZRwvow==
-        -----END EC PRIVATE KEY-----"""
+        pem2 = make_pem('EC PRIVATE KEY', """MGgCAQEEHEFjbaVPLJ3ngZyCibCvT0RLUqSlHjC5Z3e0FtugBwYFK4EEACGhPAM6
+AAT5IvL2V6m48y1JLMGr6ZbnOqNKP9hMf9mxyVkk6/SaRoBoJVkXrNIpYL0P7DS7
+QF8E/OGeZRwvow==""")
 
         key1 = ECC.import_key(pem1)
         low16 = int(key1.pointQ.y % 65536)
@@ -1665,16 +1655,12 @@ class TestExport_P256(unittest.TestCase):
     def test_compressed_curve(self):
 
         # Compressed P-256 curve (Y-point is even)
-        pem1 = """-----BEGIN EC PRIVATE KEY-----
-        MFcCAQEEIHTuc09jC51xXomV6MVCDN+DpAAvSmaJWZPTEHM6D5H1oAoGCCqGSM49
-        AwEHoSQDIgACWFuGbHe8yJ43rir7PMTE9w8vHz0BSpXHq90Xi7/s+a0=
-        -----END EC PRIVATE KEY-----"""
+        pem1 = make_pem('EC PRIVATE KEY', """MFcCAQEEIHTuc09jC51xXomV6MVCDN+DpAAvSmaJWZPTEHM6D5H1oAoGCCqGSM49
+AwEHoSQDIgACWFuGbHe8yJ43rir7PMTE9w8vHz0BSpXHq90Xi7/s+a0=""")
 
         # Compressed P-256 curve (Y-point is odd)
-        pem2 = """-----BEGIN EC PRIVATE KEY-----
-        MFcCAQEEIFggiPN9SQP+FAPTCPp08fRUz7rHp2qNBRcBJ1DXhb3ZoAoGCCqGSM49
-        AwEHoSQDIgADLpph1trTIlVfa8NJvlMUPyWvL+wP+pW3BJITUL/wj9A=
-        -----END EC PRIVATE KEY-----"""
+        pem2 = make_pem('EC PRIVATE KEY', """MFcCAQEEIFggiPN9SQP+FAPTCPp08fRUz7rHp2qNBRcBJ1DXhb3ZoAoGCCqGSM49
+AwEHoSQDIgADLpph1trTIlVfa8NJvlMUPyWvL+wP+pW3BJITUL/wj9A=""")
 
         key1 = ECC.import_key(pem1)
         low16 = int(key1.pointQ.y % 65536)
@@ -1954,20 +1940,16 @@ class TestExport_P384(unittest.TestCase):
         # Compressed P-384 curve (Y-point is even)
         # openssl ecparam -name secp384p1 -genkey -noout -conv_form compressed -out /tmp/a.pem
         # openssl ec -in /tmp/a.pem -text -noout
-        pem1 = """-----BEGIN EC PRIVATE KEY-----
-MIGkAgEBBDAM0lEIhvXuekK2SWtdbgOcZtBaxa9TxfpO/GcDFZLCJ3JVXaTgwken
+        pem1 = make_pem('EC PRIVATE KEY', """MIGkAgEBBDAM0lEIhvXuekK2SWtdbgOcZtBaxa9TxfpO/GcDFZLCJ3JVXaTgwken
 QT+C+XLtD6WgBwYFK4EEACKhZANiAATs0kZMhFDu8DoBC21jrSDPyAUn4aXZ/DM4
 ylhDfWmb4LEbeszXceIzfhIUaaGs5y1xXaqf5KXTiAAYx2pKUzAAM9lcGUHCGKJG
-k4AgUmVJON29XoUilcFrzjDmuye3B6Q=
------END EC PRIVATE KEY-----"""
+k4AgUmVJON29XoUilcFrzjDmuye3B6Q=""")
 
         # Compressed P-384 curve (Y-point is odd)
-        pem2 = """-----BEGIN EC PRIVATE KEY-----
-MIGkAgEBBDDHPFTslYLltE16fHdSDTtE/2HTmd3M8mqy5MttAm4wZ833KXiGS9oe
+        pem2 = make_pem('EC PRIVATE KEY', """MIGkAgEBBDDHPFTslYLltE16fHdSDTtE/2HTmd3M8mqy5MttAm4wZ833KXiGS9oe
 kFdx9sNV0KygBwYFK4EEACKhZANiAASLIE5RqVMtNhtBH/u/p/ifqOAlKnK/+RrQ
 YC46ZRsnKNayw3wATdPjgja7L/DSII3nZK0G6KOOVwJBznT/e+zudUJYhZKaBLRx
-/bgXyxUtYClOXxb1Y/5N7txLstYRyP0=
------END EC PRIVATE KEY-----"""
+/bgXyxUtYClOXxb1Y/5N7txLstYRyP0=""")
 
         key1 = ECC.import_key(pem1)
         low16 = int(key1.pointQ.y % 65536)
@@ -2253,22 +2235,18 @@ class TestExport_P521(unittest.TestCase):
         # Compressed P-521 curve (Y-point is even)
         # openssl ecparam -name secp521r1 -genkey -noout -conv_form compressed -out /tmp/a.pem
         # openssl ec -in /tmp/a.pem -text -noout
-        pem1 = """-----BEGIN EC PRIVATE KEY-----
-MIHcAgEBBEIAnm1CEjVjvNfXEN730p+D6su5l+mOztdc5XmTEoti+s2R4GQ4mAv3
+        pem1 = make_pem('EC PRIVATE KEY', """MIHcAgEBBEIAnm1CEjVjvNfXEN730p+D6su5l+mOztdc5XmTEoti+s2R4GQ4mAv3
 0zYLvyklvOHw0+yy8d0cyGEJGb8T3ZVKmg2gBwYFK4EEACOhgYkDgYYABAHzjTI1
 ckxQ3Togi0LAxiG0PucdBBBs5oIy3df95xv6SInp70z+4qQ2EltEmdNMssH8eOrl
 M5CYdZ6nbcHMVaJUvQEzTrYxvFjOgJiOd+E9eBWbLkbMNqsh1UKVO6HbMbW0ohCI
-uGxO8tM6r3w89/qzpG2SvFM/fvv3mIR30wSZDD84qA==
------END EC PRIVATE KEY-----"""
+uGxO8tM6r3w89/qzpG2SvFM/fvv3mIR30wSZDD84qA==""")
 
         # Compressed P-521 curve (Y-point is odd)
-        pem2 = """-----BEGIN EC PRIVATE KEY-----
-MIHcAgEBBEIB84OfhJluLBRLn3+cC/RQ37C2SfQVP/t0gQK2tCsTf5avRcWYRrOJ
+        pem2 = make_pem('EC PRIVATE KEY', """MIHcAgEBBEIB84OfhJluLBRLn3+cC/RQ37C2SfQVP/t0gQK2tCsTf5avRcWYRrOJ
 PmX9lNnkC0Hobd75QFRmdxrB0Wd1/M4jZOWgBwYFK4EEACOhgYkDgYYABAAMZcdJ
 1YLCGHt3bHCEzdidVy6+brlJIbv1aQ9fPQLF7WKNv4c8w3H8d5a2+SDZilBOsk5c
 6cNJDMz2ExWQvxl4CwDJtJGt1+LHVKFGy73NANqVxMbRu+2F8lOxkNp/ziFTbVyV
-vv6oYkMIIi7r5oQWAiQDrR2mlrrFDL9V7GH/r8SWQw==
------END EC PRIVATE KEY-----"""
+vv6oYkMIIi7r5oQWAiQDrR2mlrrFDL9V7GH/r8SWQw==""")
 
         key1 = ECC.import_key(pem1)
         low16 = int(key1.pointQ.y % 65536)

--- a/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
+++ b/lib/Crypto/SelfTest/PublicKey/test_import_RSA.py
@@ -28,7 +28,7 @@ import unittest
 from unittest import SkipTest
 
 from Crypto.PublicKey import RSA
-from Crypto.SelfTest.st_common import a2b_hex, list_test_cases
+from Crypto.SelfTest.st_common import a2b_hex, list_test_cases, make_pem
 from Crypto.IO import PEM
 from Crypto.Util.py3compat import b, tostr, FileNotFoundError
 from Crypto.Util.number import inverse
@@ -78,35 +78,30 @@ def der2pem(der, text='PUBLIC'):
 
 class ImportKeyTests(unittest.TestCase):
     # 512-bit RSA key generated with openssl
-    rsaKeyPEM = u'''-----BEGIN RSA PRIVATE KEY-----
-MIIBOwIBAAJBAL8eJ5AKoIsjURpcEoGubZMxLD7+kT+TLr7UkvEtFrRhDDKMtuII
+    rsaKeyPEM = make_pem('RSA PRIVATE KEY', """MIIBOwIBAAJBAL8eJ5AKoIsjURpcEoGubZMxLD7+kT+TLr7UkvEtFrRhDDKMtuII
 q19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQJACUSDEp8RTe32ftq8IwG8
 Wojl5mAd1wFiIOrZ/Uv8b963WJOJiuQcVN29vxU5+My9GPZ7RA3hrDBEAoHUDPrI
 OQIhAPIPLz4dphiD9imAkivY31Rc5AfHJiQRA7XixTcjEkojAiEAyh/pJHks/Mlr
 +rdPNEpotBjfV4M4BkgGAA/ipcmaAjcCIQCHvhwwKVBLzzTscT2HeUdEeBMoiXXK
 JACAr3sJQJGxIQIgarRp+m1WSKV1MciwMaTOnbU7wxFs9DP1pva76lYBzgUCIQC9
-n0CnZCJ6IZYqSt0H5N7+Q+2Ro64nuwV/OSQfM6sBwQ==
------END RSA PRIVATE KEY-----'''
+n0CnZCJ6IZYqSt0H5N7+Q+2Ro64nuwV/OSQfM6sBwQ==""")
 
     # As above, but this is actually an unencrypted PKCS#8 key
-    rsaKeyPEM8 = u'''-----BEGIN PRIVATE KEY-----
-MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAvx4nkAqgiyNRGlwS
+    rsaKeyPEM8 = make_pem('PRIVATE KEY', """MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAvx4nkAqgiyNRGlwS
 ga5tkzEsPv6RP5MuvtSS8S0WtGEMMoy24girX0WsvilQgzKY8xIsGfeEkt7fQPDj
 wZAzhQIDAQABAkAJRIMSnxFN7fZ+2rwjAbxaiOXmYB3XAWIg6tn9S/xv3rdYk4mK
 5BxU3b2/FTn4zL0Y9ntEDeGsMEQCgdQM+sg5AiEA8g8vPh2mGIP2KYCSK9jfVFzk
 B8cmJBEDteLFNyMSSiMCIQDKH+kkeSz8yWv6t080Smi0GN9XgzgGSAYAD+KlyZoC
 NwIhAIe+HDApUEvPNOxxPYd5R0R4EyiJdcokAICvewlAkbEhAiBqtGn6bVZIpXUx
 yLAxpM6dtTvDEWz0M/Wm9rvqVgHOBQIhAL2fQKdkInohlipK3Qfk3v5D7ZGjrie7
-BX85JB8zqwHB
------END PRIVATE KEY-----'''
+BX85JB8zqwHB""")
 
     # The same RSA private key as in rsaKeyPEM, but now encrypted
     rsaKeyEncryptedPEM = (
 
         # PEM encryption
         # With DES and passphrase 'test'
-        ('test', u'''-----BEGIN RSA PRIVATE KEY-----
-Proc-Type: 4,ENCRYPTED
+        ('test', make_pem('RSA PRIVATE KEY', """Proc-Type: 4,ENCRYPTED
 DEK-Info: DES-CBC,AF8F9A40BD2FA2FC
 
 Ckl9ex1kaVEWhYC2QBmfaF+YPiR4NFkRXA7nj3dcnuFEzBnY5XULupqQpQI3qbfA
@@ -115,12 +110,10 @@ C6NxQ1IJWOXzTew/xM2I26kPwHIvadq+/VaT8gLQdjdH0jOiVNaevjWnLgrn1mLP
 BCNRMdcexozWtAFNNqSzfW58MJL2OdMi21ED184EFytIc1BlB+FZiGZduwKGuaKy
 9bMbdb/1PSvsSzPsqW7KSSrTw6MgJAFJg6lzIYvR5F4poTVBxwBX3+EyEmShiaNY
 IRX3TgQI0IjrVuLmvlZKbGWP18FXj7I7k9tSsNOOzllTTdq3ny5vgM3A+ynfAaxp
-dysKznQ6P+IoqML1WxAID4aGRMWka+uArOJ148Rbj9s=
------END RSA PRIVATE KEY-----'''),
+dysKznQ6P+IoqML1WxAID4aGRMWka+uArOJ148Rbj9s=""")),
 
         # PKCS8 encryption
-        ('winter', u'''-----BEGIN ENCRYPTED PRIVATE KEY-----
-MIIBpjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIeZIsbW3O+JcCAggA
+        ('winter', make_pem('ENCRYPTED PRIVATE KEY', """MIIBpjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIeZIsbW3O+JcCAggA
 MBQGCCqGSIb3DQMHBAgSM2p0D8FilgSCAWBhFyP2tiGKVpGj3mO8qIBzinU60ApR
 3unvP+N6j7LVgnV2lFGaXbJ6a1PbQXe+2D6DUyBLo8EMXrKKVLqOMGkFMHc0UaV6
 R6MmrsRDrbOqdpTuVRW+NVd5J9kQQh4xnfU/QrcPPt7vpJvSf4GzG0n666Ki50OV
@@ -128,8 +121,7 @@ M/feuVlIiyGXY6UWdVDpcOV72cq02eNUs/1JWdh2uEBvA9fCL0c07RnMrdT+CbJQ
 NjJ7f8ULtp7xvR9O3Al/yJ4Wv3i4VxF1f3MCXzhlUD4I0ONlr0kJWgeQ80q/cWhw
 ntvgJwnCn2XR1h6LA8Wp+0ghDTsL2NhJpWd78zClGhyU4r3hqu1XDjoXa7YCXCix
 jCV15+ViDJzlNCwg+W6lRg18sSLkCT7alviIE0U5tHc6UPbbHwT5QqAxAABaP+nZ
-CGqJGyiwBzrKebjgSm/KRd4C91XqcsysyH2kKPfT51MLAoD4xelOURBP
------END ENCRYPTED PRIVATE KEY-----'''
+CGqJGyiwBzrKebjgSm/KRd4C91XqcsysyH2kKPfT51MLAoD4xelOURBP""")
         ),
     )
 

--- a/lib/Crypto/SelfTest/Signature/test_pkcs1_15.py
+++ b/lib/Crypto/SelfTest/Signature/test_pkcs1_15.py
@@ -35,7 +35,7 @@ from binascii import unhexlify
 from Crypto.Util.py3compat import bchr
 from Crypto.Util.number import bytes_to_long
 from Crypto.Util.strxor import strxor
-from Crypto.SelfTest.st_common import list_test_cases
+from Crypto.SelfTest.st_common import list_test_cases, make_pem
 from Crypto.SelfTest.loader import load_test_vectors, load_test_vectors_wycheproof
 
 from Crypto.Hash import (SHA1, SHA224, SHA256, SHA384, SHA512, SHA3_384,
@@ -149,15 +149,13 @@ class PKCS1_15_NoParams(unittest.TestCase):
     """Verify that PKCS#1 v1.5 signatures pass even without NULL parameters in
     the algorithm identifier (PyCrypto/LP bug #1119552)."""
 
-    rsakey = """-----BEGIN RSA PRIVATE KEY-----
-            MIIBOwIBAAJBAL8eJ5AKoIsjURpcEoGubZMxLD7+kT+TLr7UkvEtFrRhDDKMtuII
-            q19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQJACUSDEp8RTe32ftq8IwG8
-            Wojl5mAd1wFiIOrZ/Uv8b963WJOJiuQcVN29vxU5+My9GPZ7RA3hrDBEAoHUDPrI
-            OQIhAPIPLz4dphiD9imAkivY31Rc5AfHJiQRA7XixTcjEkojAiEAyh/pJHks/Mlr
-            +rdPNEpotBjfV4M4BkgGAA/ipcmaAjcCIQCHvhwwKVBLzzTscT2HeUdEeBMoiXXK
-            JACAr3sJQJGxIQIgarRp+m1WSKV1MciwMaTOnbU7wxFs9DP1pva76lYBzgUCIQC9
-            n0CnZCJ6IZYqSt0H5N7+Q+2Ro64nuwV/OSQfM6sBwQ==
-            -----END RSA PRIVATE KEY-----"""
+    rsakey = make_pem('RSA PRIVATE KEY', """MIIBOwIBAAJBAL8eJ5AKoIsjURpcEoGubZMxLD7+kT+TLr7UkvEtFrRhDDKMtuII
+q19FrL4pUIMymPMSLBn3hJLe30Dw48GQM4UCAwEAAQJACUSDEp8RTe32ftq8IwG8
+Wojl5mAd1wFiIOrZ/Uv8b963WJOJiuQcVN29vxU5+My9GPZ7RA3hrDBEAoHUDPrI
+OQIhAPIPLz4dphiD9imAkivY31Rc5AfHJiQRA7XixTcjEkojAiEAyh/pJHks/Mlr
++rdPNEpotBjfV4M4BkgGAA/ipcmaAjcCIQCHvhwwKVBLzzTscT2HeUdEeBMoiXXK
+JACAr3sJQJGxIQIgarRp+m1WSKV1MciwMaTOnbU7wxFs9DP1pva76lYBzgUCIQC9
+n0CnZCJ6IZYqSt0H5N7+Q+2Ro64nuwV/OSQfM6sBwQ==""")
 
     msg = b"This is a test\x0a"
 

--- a/lib/Crypto/SelfTest/Signature/test_pss.py
+++ b/lib/Crypto/SelfTest/Signature/test_pss.py
@@ -33,7 +33,7 @@ import unittest
 from Crypto.Util.py3compat import b, bchr
 from Crypto.Util.number import bytes_to_long
 from Crypto.Util.strxor import strxor
-from Crypto.SelfTest.st_common import list_test_cases
+from Crypto.SelfTest.st_common import list_test_cases, make_pem
 from Crypto.SelfTest.loader import load_test_vectors, load_test_vectors_wycheproof
 
 from Crypto.Hash import SHA1, SHA224, SHA256, SHA384, SHA512
@@ -62,7 +62,31 @@ class PRNG(object):
 
 class PSS_Tests(unittest.TestCase):
 
-    rsa_key = b'-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAsvI34FgiTK8+txBvmooNGpNwk23YTU51dwNZi5yha3W4lA/Q\nvcZrDalkmD7ekWQwnduxVKa6pRSI13KBgeUOIqJoGXSWhntEtY3FEwvWOHW5AE7Q\njUzTzCiYT6TVaCcpa/7YLai+p6ai2g5f5Zfh4jSawa9uYeuggFygQq4IVW796MgV\nyqxYMM/arEj+/sKz3Viua9Rp9fFosertCYCX4DUTgW0mX9bwEnEOgjSI3pLOPXz1\n8vx+DRZS5wMCmwCUa0sKonLn3cAUPq+sGix7+eo7T0Z12MU8ud7IYVX/75r3cXiF\nPaYE2q8Le0kgOApIXbb+x74x0rNgyIh1yGygkwIDAQABAoIBABz4t1A0pLT6qHI2\nEIOaNz3mwhK0dZEqkz0GB1Dhtoax5ATgvKCFB98J3lYB08IBURe1snOsnMpOVUtg\naBRSM+QqnCUG6bnzKjAkuFP5liDE+oNQv1YpKp9CsUovuzdmI8Au3ewihl+ZTIN2\nUVNYMEOR1b5m+z2SSwWNOYsiJwpBrT7zkpdlDyjat7FiiPhMMIMXjhQFVxURMIcB\njUBtPzGvV/PG90cVDWi1wRGeeP1dDqti/jsnvykQ15KW1MqGrpeNKRmDdTy/Ucl1\nWIoYklKw3U456lgZ/rDTDB818+Tlnk35z4yF7d5ANPM8CKfqOPcnO1BCKVFzf4eq\n54wvUtkCgYEA1Zv2lp06l7rXMsvNtyYQjbFChezRDRnPwZmN4NCdRtTgGG1G0Ryd\nYz6WWoPGqZp0b4LAaaHd3W2GTcpXF8WXMKfMX1W+tMAxMozfsXRKMcHoypwuS5wT\nfJRXJCG4pvd57AB0iVUEJW2we+uGKU5Zxcx//id2nXGCpoRyViIplQsCgYEA1nVC\neHupHChht0Fh4N09cGqZHZzuwXjOUMzR3Vsfz+4WzVS3NvIgN4g5YgmQFOeKwo5y\niRq5yvubcNdFvf85eHWClg0zPAyxJCVUWigCrrOanGEhJo6re4idJvNVzu4Ucg0v\n6B3SJ1HsCda+ZSNz24bSyqRep8A+RoAaoVSFx5kCgYEAn3RvXPs9s+obnqWYiPF3\nRe5etE6Vt2vfNKwFxx6zaR6bsmBQjuUHcABWiHb6I71S0bMPI0tbrWGG8ibrYKl1\nNTLtUvVVCOS3VP7oNTWT9RTFTAnOXU7DFSo+6o/poWn3r36ff6zhDXeWWMr2OXtt\ndEQ1/2lCGEGVv+v61eVmmQUCgYABFHITPTwqwiFL1O5zPWnzyPWgaovhOYSAb6eW\n38CXQXGn8wdBJZL39J2lWrr4//l45VK6UgIhfYbY2JynSkO10ZGow8RARygVMILu\nOUlaK9lZdDvAf/NpGdUAvzTtZ9F+iYZ2OsA2JnlzyzsGM1l//3vMPWukmJk3ral0\nqoJJ8QKBgGRG3eVHnIegBbFVuMDp2NTcfuSuDVUQ1fGAwtPiFa8u81IodJnMk2pq\niXu2+0ytNA/M+SVrAnE2AgIzcaJbtr0p2srkuVM7KMWnG1vWFNjtXN8fAhf/joOv\nD+NmPL/N4uE57e40tbiU/H7KdyZaDt+5QiTmdhuyAe6CBjKsF2jy\n-----END RSA PRIVATE KEY-----'
+    rsa_key = make_pem('RSA PRIVATE KEY', """MIIEowIBAAKCAQEAsvI34FgiTK8+txBvmooNGpNwk23YTU51dwNZi5yha3W4lA/Q
+vcZrDalkmD7ekWQwnduxVKa6pRSI13KBgeUOIqJoGXSWhntEtY3FEwvWOHW5AE7Q
+jUzTzCiYT6TVaCcpa/7YLai+p6ai2g5f5Zfh4jSawa9uYeuggFygQq4IVW796MgV
+yqxYMM/arEj+/sKz3Viua9Rp9fFosertCYCX4DUTgW0mX9bwEnEOgjSI3pLOPXz1
+8vx+DRZS5wMCmwCUa0sKonLn3cAUPq+sGix7+eo7T0Z12MU8ud7IYVX/75r3cXiF
+PaYE2q8Le0kgOApIXbb+x74x0rNgyIh1yGygkwIDAQABAoIBABz4t1A0pLT6qHI2
+EIOaNz3mwhK0dZEqkz0GB1Dhtoax5ATgvKCFB98J3lYB08IBURe1snOsnMpOVUtg
+aBRSM+QqnCUG6bnzKjAkuFP5liDE+oNQv1YpKp9CsUovuzdmI8Au3ewihl+ZTIN2
+UVNYMEOR1b5m+z2SSwWNOYsiJwpBrT7zkpdlDyjat7FiiPhMMIMXjhQFVxURMIcB
+jUBtPzGvV/PG90cVDWi1wRGeeP1dDqti/jsnvykQ15KW1MqGrpeNKRmDdTy/Ucl1
+WIoYklKw3U456lgZ/rDTDB818+Tlnk35z4yF7d5ANPM8CKfqOPcnO1BCKVFzf4eq
+54wvUtkCgYEA1Zv2lp06l7rXMsvNtyYQjbFChezRDRnPwZmN4NCdRtTgGG1G0Ryd
+Yz6WWoPGqZp0b4LAaaHd3W2GTcpXF8WXMKfMX1W+tMAxMozfsXRKMcHoypwuS5wT
+fJRXJCG4pvd57AB0iVUEJW2we+uGKU5Zxcx//id2nXGCpoRyViIplQsCgYEA1nVC
+eHupHChht0Fh4N09cGqZHZzuwXjOUMzR3Vsfz+4WzVS3NvIgN4g5YgmQFOeKwo5y
+iRq5yvubcNdFvf85eHWClg0zPAyxJCVUWigCrrOanGEhJo6re4idJvNVzu4Ucg0v
+6B3SJ1HsCda+ZSNz24bSyqRep8A+RoAaoVSFx5kCgYEAn3RvXPs9s+obnqWYiPF3
+Re5etE6Vt2vfNKwFxx6zaR6bsmBQjuUHcABWiHb6I71S0bMPI0tbrWGG8ibrYKl1
+NTLtUvVVCOS3VP7oNTWT9RTFTAnOXU7DFSo+6o/poWn3r36ff6zhDXeWWMr2OXtt
+dEQ1/2lCGEGVv+v61eVmmQUCgYABFHITPTwqwiFL1O5zPWnzyPWgaovhOYSAb6eW
+38CXQXGn8wdBJZL39J2lWrr4//l45VK6UgIhfYbY2JynSkO10ZGow8RARygVMILu
+OUlaK9lZdDvAf/NpGdUAvzTtZ9F+iYZ2OsA2JnlzyzsGM1l//3vMPWukmJk3ral0
+qoJJ8QKBgGRG3eVHnIegBbFVuMDp2NTcfuSuDVUQ1fGAwtPiFa8u81IodJnMk2pq
+iXu2+0ytNA/M+SVrAnE2AgIzcaJbtr0p2srkuVM7KMWnG1vWFNjtXN8fAhf/joOv
+D+NmPL/N4uE57e40tbiU/H7KdyZaDt+5QiTmdhuyAe6CBjKsF2jy""", as_bytes=True)
     msg = b'AAA'
     tag = b'\x00[c5\xd8\xb0\x8b!D\x81\x83\x07\xc0\xdd\xb9\xb4\xb2`\x92\xe7\x02\xf1\xe1P\xea\xc3\xf0\xe3>\xddX5\xdd\x8e\xc5\x89\xef\xf3\xc2\xdc\xfeP\x02\x7f\x12+\xc9\xaf\xbb\xec\xfe\xb0\xa5\xb9\x08\x11P\x8fL\xee5\x9b\xb0k{=_\xd2\x14\xfb\x01R\xb7\xfe\x14}b\x03\x8d5Y\x89~}\xfc\xf2l\xd01-\xbd\xeb\x11\xcdV\x11\xe9l\x19k/o5\xa2\x0f\x15\xe7Q$\t=\xec\x1dAB\x19\xa5P\x9a\xaf\xa3G\x86"\xd6~\xf0<p5\x00\x86\xe0\xf3\x99\xc7+\xcfc,\\\x13)v\xcd\xff\x08o\x90\xc5\xd1\xca\x869\xf45\x1e\xfd\xa2\xf1n\xa3\xa6e\xc5\x11Q\xe4@\xbd\x17\x83x\xc9\x9b\xb5\xc7\xea\x03U\x9b\xa0\xccC\x17\xc9T\x86/\x05\x1c\xc7\x95hC\xf9b1\xbb\x05\xc3\xf0\x9a>j\xfcqkbs\x13\x84b\xe4\xbdm(\xed`\xa4F\xfb\x8f.\xe1\x8c)/_\x9eS\x98\xa4v\xb8\xdc\xfe\xf7/D\x18\x19\xb3T\x97:\xe2\x96s\xe8<\xa2\xb4\xb9\xf8/'
 

--- a/lib/Crypto/SelfTest/st_common.py
+++ b/lib/Crypto/SelfTest/st_common.py
@@ -52,4 +52,12 @@ def b2a_hex(s):
     # For completeness
     return binascii.b2a_hex(s)
 
+def make_pem(marker, body, as_bytes=False):
+    """Reconstruct a PEM block from its marker and payload."""
+    lines = [line.strip() for line in body.strip().splitlines()]
+    pem = "-----BEGIN " + marker + "-----\n"
+    pem += "\n".join(lines)
+    pem += "\n-----END " + marker + "-----"
+    return b(pem) if as_bytes else pem
+
 # vim:set ts=4 sw=4 sts=4 expandtab:


### PR DESCRIPTION
Closes #904.

This keeps `Crypto.SelfTest` installed and runnable, but avoids embedding full PEM private-key markers directly in the installed self-test source files.

Changes:
- Add a small `make_pem()` helper for self-test fixtures.
- Refactor RSA, DSA, ECC, ECDH, PKCS#1, and PSS self-test fixtures to reconstruct PEM blocks at runtime.
- Preserve the existing self-test coverage and package layout.
- Add a changelog entry for GH#904.

Validation:
- `rg -n -- '-----BEGIN (RSA |DSA |EC |ENCRYPTED )?PRIVATE KEY-----' lib/Crypto/SelfTest build/.../Crypto/SelfTest`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc python3 -m compileall -q lib/Crypto/SelfTest`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc python3 setup.py test -m PublicKey`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc python3 setup.py test -m Cipher`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc python3 setup.py test -m Signature`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc python3 setup.py test -m Protocol`
- `PYTHONPYCACHEPREFIX=/private/tmp/pycryptodome-pyc PYTHONPATH=build/lib.macosx-10.9-universal2-3.9 python3 -m Crypto.SelfTest PublicKey`