### PR TITLE
Fix incorrect "v1.5" in PKCS#1 OAEP cipher docstring

### DIFF
--- a/lib/Crypto/Cipher/PKCS1_OAEP.py
+++ b/lib/Crypto/Cipher/PKCS1_OAEP.py
@@ -32,7 +32,7 @@ from ._pkcs1_oaep_decode import oaep_decode
 
 
 class PKCS1OAEP_Cipher:
-    """Cipher object for PKCS#1 v1.5 OAEP.
+    """Cipher object for PKCS#1 OAEP.
     Do not create directly: use :func:`new` instead."""
 
     def __init__(self, key, hashAlgo, mgfunc, label, randfunc):


### PR DESCRIPTION
Fixes #916.

The `PKCS1OAEP_Cipher` docstring said "PKCS#1 v1.5 OAEP", but OAEP is PKCS#1 v2.0 (RSAES-OAEP) - "v1.5" refers to the older RSAES-PKCS1-v1_5 scheme (in PKCS1_v1_5.py). Dropped the incorrect "v1.5" to match the rest of the module (the __init__ docstring already says just "PKCS#1 OAEP").