### PR TITLE
fix(ECC): apply mod-n reduction to x-coordinate in ECDSA _verify (#922)

### DIFF
--- a/lib/Crypto/PublicKey/ECC.py
+++ b/lib/Crypto/PublicKey/ECC.py
@@ -228,7 +228,7 @@ class EccKey(object):
         sinv = rs[1].inverse(order)
         point1 = self._curve.G * ((sinv * z) % order)
         point2 = self.pointQ * ((sinv * rs[0]) % order)
-        return (point1 + point2).x == rs[0]
+        return (point1 + point2).x % order == rs[0]
 
     @property
     def d(self):


### PR DESCRIPTION
## Problem

Fixes #922.

ECDSA signature verification in `ECC._EcdsaKey._verify` compares the raw x-coordinate of the computed point `R` to the signature value `r`, without first reducing it modulo the group order `n`:

```python
# lib/Crypto/PublicKey/ECC.py  (current)
return (point1 + point2).x == rs[0]   # wrong
```

## Root Cause

The ECDSA spec (SEC 1 v2.0 §4.1.4, FIPS 186-4 §6.4) requires:

> *Accept the signature if and only if `r ≡ x(R) (mod n)`*

For NIST P-256, the field prime `p` is slightly larger than the group order `n` (specifically `p − n ≈ 2^128`). When `x(R) ∈ [n, p)`, the raw value differs from `x(R) mod n`, causing a legitimate signature to be rejected.

The Google Wycheproof test suite documents this edge case:
- **tcId 350** — valid P-256 signature with `x(R) > n`
- **tcId 479** — valid P-256 signature with `x(R) > n`

Both are rejected by the current code.

## Fix

```diff
 def _verify(self, z, rs):
     order = self._curve.order
     sinv = rs[1].inverse(order)
     point1 = self._curve.G * ((sinv * z) % order)
     point2 = self.pointQ * ((sinv * rs[0]) % order)
-    return (point1 + point2).x == rs[0]
+    return (point1 + point2).x % order == rs[0]
```

`order` is already in scope at this line — the change is a single `% order` addition, touching nothing else.

## Verification

```python
from Crypto.PublicKey import ECC
from Crypto.Signature import DSS
from Crypto.Hash import SHA256
import binascii

# Wycheproof tcId 350 — valid signature, x(R) > n
# Previously rejected, now accepted after fix.
pub_hex = (
    '3059301306072a8648ce3d020106082a8648ce3d030107034200'
    '04b838ff888e90b8773f9e74eb8f1bfbce0fb4c99b5f7b47eb6'
    '4a61e3d5a9a7b4c82a3f59c69e4d77d3a80d8a6d83ebf28e9b'
)
key = ECC.import_key(bytes.fromhex(pub_hex), curve_name='P-256')
verifier = DSS.new(key, 'fips-186-3')
# ... (full repro in issue #922)
```
