### PR TITLE
Fix incorrect minimum-length error message in KWP mode

### DIFF
--- a/lib/Crypto/Cipher/_mode_kwp.py
+++ b/lib/Crypto/Cipher/_mode_kwp.py
@@ -91,7 +91,7 @@ class KWPMode(object):
             raise ValueError("The ciphertext must have length multiple of 8 bytes")
 
         if len(ciphertext) < 16:
-            raise ValueError("The ciphertext must be at least 24 bytes long")
+            raise ValueError("The ciphertext must be at least 16 bytes long")
 
         if len(ciphertext) == 16:
             S = self._cipher.decrypt(ciphertext)


### PR DESCRIPTION
When `unseal()` rejects ciphertext shorter than 16 bytes, the error message claimed it "must be at least 24 bytes long".

Changed it so it reflects the check.