### PR TITLE
fix(ecc): reduce ECDSA x-coordinate

### DIFF
--- a/lib/Crypto/PublicKey/ECC.py
+++ b/lib/Crypto/PublicKey/ECC.py
@@ -228,7 +228,7 @@ class EccKey(object):
         sinv = rs[1].inverse(order)
         point1 = self._curve.G * ((sinv * z) % order)
         point2 = self.pointQ * ((sinv * rs[0]) % order)
-        return (point1 + point2).x == rs[0]
+        return (point1 + point2).x % order == rs[0]
 
     @property
     def d(self):

--- a/lib/Crypto/SelfTest/Signature/test_dss.py
+++ b/lib/Crypto/SelfTest/Signature/test_dss.py
@@ -1345,8 +1345,6 @@ class TestVectorsECDSAWycheproof(unittest.TestCase):
         except ValueError as e:
             if tv.warning:
                 return
-            if tv.comment == "k*G has a large x-coordinate":
-                return
             assert not tv.valid
         else:
             assert tv.valid

--- a/lib/Crypto/SelfTest/Signature/test_dss.py
+++ b/lib/Crypto/SelfTest/Signature/test_dss.py
@@ -240,6 +240,20 @@ class FIPS_ECDSA_Tests(unittest.TestCase):
         verifier = DSS.new(self.key_pub, 'fips-186-3')
         verifier.verify(hashed_msg, signature)
 
+    def test_verify_p256_large_x_coordinate(self):
+        # Wycheproof ecdsa_secp256r1_sha256_test.json, tcId 285
+        key = ECC.import_key("""-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECtmVACiNRmlAAx1yqfVEWk1DeEZA
+hVvwpph00t5f4QPFAR5u8sQtzVDV09Kfma5uuiyAySRPTFQi8Jef8MO6Xg==
+-----END PUBLIC KEY-----""")
+        signature = unhexlify(
+            "303502104319055358e8617b0c46353d039cdaab"
+            "022100ffffffff00000000ffffffffffffffff"
+            "bce6faada7179e84f3b9cac2fc63254e")
+        verifier = DSS.new(key, 'fips-186-3', encoding='der')
+
+        verifier.verify(SHA256.new(b"123400"), signature)
+
     def test_negative_unapproved_hashes(self):
         """Verify that unapproved hashes are rejected"""
 


### PR DESCRIPTION
## Summary

ECDSA verification compared the recomputed affine x-coordinate directly with `r`. Valid ECDSA verification requires comparing `x mod n` with `r`, where `n` is the curve order.

As a result, valid signatures with a recomputed x-coordinate greater than or equal to `n` were rejected. This is a correctness and interoperability issue. It causes false negatives but does not allow invalid signatures or forgeries.

[SEC 1: Elliptic Curve Cryptography, Version 2.0](https://www.secg.org/sec1-v2.pdf) Section 4.1.4, steps 7–8, specifies that ECDSA verification must compute `v = xR mod n` and compare `v` with `r`.

## Changes

- Reduce the recomputed x-coordinate modulo the curve order before comparing it with `r`.
- Add a P-256/SHA-256 regression test based on a valid [Project Wycheproof](https://github.com/C2SP/wycheproof) vector. The regression is covered both directly and by the extended Wycheproof suite.
- Remove the existing Wycheproof exception that silently skipped signatures labeled `k*G has a large x-coordinate`.

The regression vector is tcId 285 in the Wycheproof corpus bundled with PyCryptodome. The same vector is [tcId 350 in the current C2SP Wycheproof corpus](https://github.com/C2SP/wycheproof/blob/main/testvectors_v1/ecdsa_secp256r1_sha256_test.json#L3665-L3674).
